### PR TITLE
remove unnecessary psycopg2 requirement

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -52,7 +52,6 @@ path.py==3.0.1
 Pillow==1.7.8
 pip>=1.4
 polib==1.0.3
-psycopg2==2.5.2
 pycrypto>=2.6
 pygments==1.6
 pygraphviz==1.1


### PR DESCRIPTION
@jrbl @sefk 

Should be a real quick one. We don't need psycopg2 (which I added a while back) b/c we don't run postgres in any env.
