### PR TITLE
Allow <img> tags in LTI2.0 feedback

### DIFF
--- a/common/lib/xmodule/xmodule/lti_module.py
+++ b/common/lib/xmodule/xmodule/lti_module.py
@@ -350,7 +350,11 @@ class LTIModule(LTIFields, LTI20ModuleMixin, XModule):
         #     'acronym': ['title'],
         #
         # This lets all plaintext through.
-        sanitized_comment = bleach.clean(self.score_comment)
+        allowed_tags = bleach.ALLOWED_TAGS + [u'img']
+        allowed_attrs = bleach.ALLOWED_ATTRIBUTES.copy()
+        allowed_attrs[u'img'] = [u'src', u'height', u'width', u'alt', u'title']
+
+        sanitized_comment = bleach.clean(self.score_comment, tags=allowed_tags, attributes=allowed_attrs)
 
         return {
             'input_fields': self.get_input_fields(),

--- a/common/lib/xmodule/xmodule/tests/test_lti20_unit.py
+++ b/common/lib/xmodule/xmodule/tests/test_lti20_unit.py
@@ -37,6 +37,8 @@ class LTI20RESTResultServiceTest(LogicTest):
             (u"plaintext", u"plaintext"),
             (u"a <script>alert(3)</script>", u"a &lt;script&gt;alert(3)&lt;/script&gt;"),  # encodes scripts
             (u"<b>bold 包</b>", u"<b>bold 包</b>"),  # unicode, and <b> tags pass through
+            (u'<img src="image.jpg" alt="alt" title="title" height="50" width="50">',  # attributes are not identical
+             u'<img src="image.jpg" alt="alt" height="50" width="50" title="title">')  # b/c sanitizer changes order
         )
         for case in test_cases:
             self.xmodule.score_comment = case[0]


### PR DESCRIPTION
@sefk 

This is to enable img tags in LTI feedback.
