### PR TITLE
Fix failing munge_tabs test

### DIFF
--- a/common/lib/xmodule/xmodule/tabs.py
+++ b/common/lib/xmodule/xmodule/tabs.py
@@ -628,9 +628,9 @@ class OpenEndedGradingTab(AuthenticatedCourseTab, GradingTab):
 
     def __init__(self, tab_dict=None):  # pylint: disable=unused-argument
         super(OpenEndedGradingTab, self).__init__(
-            # Translators: "Open Ended Panel" appears on a tab that, when clicked, opens up a panel that
+            # Translators: "Assessment Panel" appears on a tab that, when clicked, opens up a panel that
             # displays information about open-ended problems that a user has submitted or needs to grade
-            name=_("Open Ended Panel"),
+            name=_("Assessment Panel"),
             tab_id=self.type,
             link_func=link_reverse_func('open_ended_notifications'),
         )

--- a/common/lib/xmodule/xmodule/tests/test_tabs.py
+++ b/common/lib/xmodule/xmodule/tests/test_tabs.py
@@ -298,7 +298,7 @@ class GradingTestCase(TabTestCase):
         self.check_can_display_results(peer_grading_tab, for_authenticated_users_only=True)
         open_ended_grading_tab = self.check_grading_tab(
             tabs.OpenEndedGradingTab,
-            'Open Ended Panel',
+            'Assessment Panel',
             'open_ended_notifications'
         )
         self.check_can_display_results(open_ended_grading_tab, for_authenticated_users_only=True)

--- a/docs/en_us/course_authors/source/exercises_tools/open_response_assessment.rst
+++ b/docs/en_us/course_authors/source/exercises_tools/open_response_assessment.rst
@@ -614,13 +614,13 @@ The Staff Grading Page
 =======================
 
 When a response is available for you to grade, a yellow exclamation mark
-appears next to **Open Ended Panel** at the top of the screen.
+appears next to **Assessment Panel** at the top of the screen.
 
 .. image:: /Images/OpenEndedPanel.png
 
-To access the **Staff Grading** page, click **Open Ended Panel**.
+To access the **Staff Grading** page, click **Assessment Panel**.
 
-When the **Open Ended Console** page opens, click **Staff Grading**.
+When the **Assessment Console** page opens, click **Staff Grading**.
 Notice the **New submissions to grade** notification.
 
 .. image:: /Images/OpenEndedConsole_NewSubmissions.png
@@ -762,19 +762,20 @@ Note that if the same 20-point problem changes the assessment order, the student
 Accessing Scores
 ================
 
-You access your scores for your responses to AI and peer assessment problems through the **Open Ended Console** page.
+You access your scores for your responses to AI and peer assessment
+problems through the **Assessment Console** page.
 
-#. From any page in the LMS, click the **Open Ended Panel** tab at the
+#. From any page in the LMS, click the **Assessment Panel** tab at the
    top of the page.
 
 .. image:: /Images/OpenEndedPanel.png
 
-2. On the **Open Ended Console** page, click **Problems You Have
+2. On the **Assessment Console** page, click **Problems You Have
    Submitted**.
 
 .. image:: /Images/ProblemsYouHaveSubmitted.png
 
-3. On the **Open Ended Problems** page, check the **Status** column to
+3. On the **Assessment Problems** page, check the **Status** column to
    see whether your responses have been graded.
 #. When grading for a problem has been finished, click the name of a
    problem in the list to see your score for that problem. When you

--- a/docs/en_us/course_authors/source/students/ora_students.rst
+++ b/docs/en_us/course_authors/source/students/ora_students.rst
@@ -199,7 +199,7 @@ the way that the course is set up.
 
 -  Through the **Open Ended Console** page. This option is always
    available for every course. To access the **Open Ended Console** page,
-   click the **Open Ended Panel** tab at the top of any page in the course.
+   click the **Assessment Panel** tab at the top of any page in the course.
    When you see the list of problems that have responses available to grade,
    click the name of the problem that you want to open it.
 
@@ -356,7 +356,7 @@ the score.
 
 For *peer assessments* and *AI assessments*, you'll access your scores through the **Open Ended Console** page.
 
-#. In the EdX Demo course, click the **Open Ended Panel** tab at the top
+#. In the EdX Demo course, click the **Assessment Panel** tab at the top
    of the page.
 
 #. On the **Open Ended Console** page, click **Problems You Have


### PR DESCRIPTION
This replaces all remaining occurrences of 'Open Ended Panel' with
'Assessment Panel'.

This was originally introduced in
cf95f7fa72e7eb597a2ca9359949827643bd585a
