### PR TITLE
Lock version of requests-oauthlib to 0.4.0

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -66,6 +66,7 @@ pytz==2012h
 pysrt==0.4.7
 PyYAML==3.10
 requests==1.2.3
+requests-oauthlib==0.4.0
 scipy==0.11.0
 Shapely==1.2.16
 singledispatch==3.4.0.2


### PR DESCRIPTION
(cherry picked from commit c54b8db6a7863ab6b0fea42c374338a8b3dd5d0a)

@jrbl 
