### PR TITLE
Fork password-reset page to have stanford stuff

### DIFF
--- a/lms/templates/registration/password_reset_confirm.html
+++ b/lms/templates/registration/password_reset_confirm.html
@@ -53,7 +53,9 @@
 <header class="global">
   <nav>
     <h1 class="logo">
-      <a href="{{MKTG_URL_ROOT}}"><img src="{% static 'images/header-logo.png' %}"></a>
+      <a href="{{MKTG_URL_ROOT}}">
+          <img src="{% static 'themes/stanford/images/stanford-S-logo.png' %}" height="35" alt="Home Page" />
+      </a>
     </h1>
   </nav>
 </header>
@@ -157,7 +159,7 @@
       <div class="cta cta-help">
         <h3>{% trans "Need Help?" %}</h3>
         <p>
-          {% blocktrans with start_link='<a href="{{MKTG_URL_FAQ}}">' end_link='</a>' %}
+          {% blocktrans with start_link='<a href="https://stanfordonline.zendesk.com/hc">' end_link='</a>' %}
               View our {{ start_link }}help section for contact information and answers to commonly asked questions{{ end_link }}
           {% endblocktrans %}
         </p>


### PR DESCRIPTION
This PR forks the password_reset_confirm template to have the Stanford logo and help link.

@jrbl 
