### PR TITLE
Bulksettings -> Problem Settings name change

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -484,7 +484,7 @@ COURSE_UTILITIES = [
          {"short_description": "Bulk view problem settings",
           "long_description": "This utility will allow you to view all section, subsection and problem settings in one page.",
           "action_url": "utility_bulksettings_handler",
-          "action_text": "Check Bulk Settings",
+          "action_text": "View Problem Settings",
           "action_external" : False}
           ]
     }

--- a/cms/templates/bulksettings.html
+++ b/cms/templates/bulksettings.html
@@ -14,7 +14,7 @@
   <header class="mast has-actions has-subtitle">
     <h1 class="page-header">
       <small class="subtitle">${_("Tools / Course Utilities")}</small>
-      <span class="sr">&gt; </span>${_("Bulk Settings")}
+      <span class="sr">&gt; </span>${_("Problem Settings")}
     </h1>
   </header>
 </div>
@@ -89,9 +89,9 @@
 
     <aside class="content-supplementary" role="complimentary">
       <div class="bit">
-        <h3 class="title title-3">${_("What is bulk settings?")}</h3>
+        <h3 class="title title-3">${_("What is problem settings?")}</h3>
         <p>
-          ${_("The bulk settings page provides a way to view all problem settings of the current course in one page.")}
+          ${_("The problem settings page provides a way to view all problem settings of the current course in one page.")}
         </p>
       </div>
 


### PR DESCRIPTION
changing bulksettings viewnaming from "bulk settings" to "problem settings" since it current only supports bulk view of problem settings. Later we can change it back to "bulk settings" if we choose to add more functionalities. 

@jrbl
