### PR TITLE
Fix Enrollment Email UI/UX

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -43,7 +43,6 @@ class CourseDetailsTestCase(CourseTestCase):
         self.assertIsNone(details.intro_video, "intro_video somehow initialized" + str(details.intro_video))
         self.assertIsNone(details.effort, "effort somehow initialized" + str(details.effort))
         self.assertFalse(details.enable_enrollment_email, "Enrollment Email should be initialized as false")
-        self.assertTrue(details.enable_default_enrollment_email, "Default Template option for enrollment email should be initialized as true")
 
     def test_encoder(self):
         details = CourseDetails.fetch(self.course.id)

--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -26,7 +26,8 @@ class CourseMetadata(object):
                      'name',  # from xblock
                      'tags',  # from xblock
                      'video_speed_optimizations',
-                     'visible_to_staff_only'
+                     'visible_to_staff_only',
+                     'enable_enrollment_email'
     ]
 
     @classmethod

--- a/cms/static/sass/views/_settings.scss
+++ b/cms/static/sass/views/_settings.scss
@@ -119,6 +119,17 @@
       font-weight: 400;
     }
 
+    .send-test-email {
+      @extend %ui-btn-flat-outline;
+      float: right;
+    }
+
+    .fill-default-email {
+      @extend %ui-btn-flat-outline;
+      float: right;
+      margin-right: 10px;
+    }
+
     .new-button {
       // @extend %t-action3; - bad buttons won't render this properly
       @include font-size(14);
@@ -132,6 +143,11 @@
 
       .field {
         margin: 0 0 ($baseline*2) 0;
+
+        &.text .subject {
+          height: 40px;
+          resize: none;
+        }
 
         &:last-child {
           margin-bottom: 0;

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -225,53 +225,6 @@ require(["domReady!", "jquery", "js/models/settings/course_details", "js/views/s
                 </li>
                 % endif
 
-                <li class="field text" id="field-enable-enrollment-email">
-                  <label for="course-email">${_("Course Enrollment Email")}</label>
-                  <input type="checkbox" id="enable-enrollment-email"/>
-                  <label for="enable-enrollment-email">${_("Enable enrollment emails")}</label>
-                </li>
-
-                <li class="field text" id="field-enable-default-enrollment-email">
-                  <input type="checkbox" id="enable-default-enrollment-email"/>
-                  <label for="enable-enrollment-email">${_("Use default enrollment emails")}</label>
-                </li>
-
-                <li class="field text" id="field-pre-enrollment-email-subject">
-                  <label for="pre-enrollment-email-subject">${_("Subject of the Email sent to students who enroll before the course starts")}</label>
-                  <textarea class = 'text' id="pre-enrollment-email-subject"></textarea>
-                </li>
-
-                <li class="field text" id="field-pre-enrollment-email">
-                  <label for="pre-enrollment-email">${_("Email sent to students who enroll before the course starts")}</label>
-                  <textarea class="tinymce text-editor" id="pre-enrollment-email"></textarea>
-                  <span class="tip tip-stacked">${_("This email will be sent to any student who enrolls in the course before its start date")}</span>
-                  <ul class="list-actions">
-                    <li class="action-item">
-                      <a title="${_('Send me a copy of this via email')}"
-                          href="" class="action action-primary">
-                          ${_("Send me a test email")}</a>
-                    </li>
-                  </ul>
-                </li>
-                <li class="field text" id="field-post-enrollment-email-subject">
-                  <label for="post-enrollment-email-subject">${_("Subject of the Email sent to students who enroll after the course starts")}</label>
-                  <textarea class = 'text' id="post-enrollment-email-subject"></textarea>
-                </li>
-
-                <li class="field text" id="field-post-enrollment-email">
-                  <label for="post-enrollment-email">${_("Email sent to students who enroll after the course starts")}</label>
-                  <textarea class="tinymce text-editor" id="post-enrollment-email"></textarea>
-                  <span class="tip tip-stacked">${_("This email will be sent to any student who enrolls in the course after its start date")}</span>
-                  <ul class="list-actions">
-                    <li class="action-item">
-                      <a title="${_('Send me a copy of this via email')}"
-                          href="" class="action action-primary">
-                          ${_("Send me a test email")}</a>
-                    </li>
-                  </ul>
-                </li>
-
-
                 <li class="field image" id="field-course-image">
                   <label>${_("Course Image")}</label>
                   <div class="current current-course-image">
@@ -321,6 +274,65 @@ require(["domReady!", "jquery", "js/models/settings/course_details", "js/views/s
                 % endif
               </ol>
             </section>
+
+        <hr class="divide" />
+        <section class="group-settings enrollment-email">
+          <header>
+            <h2 class="title-2">${_("Course Enrollment Email")}</h2>
+            <span class="tip">${_("Settings for emails that students receive upon course enrollment")}</span>
+          </header>
+          <section class="group-settings">
+            <p><strong>By default, this feature is disabled.</strong> You can either use the default email content or create your own.<br />
+              Students enrolling right on the start date will receive the post-course-start email.<br />
+            </p>
+            <input type="checkbox" id="enable-enrollment-email"/><!-- IMPORTANT -->
+            <label for="enable-enrollment-email">${_("Enable enrollment emails")}</label>
+          </section>
+          <section class="group-settings" id="enrollment-email-settings"><!-- IMPORTANT -->
+            <section class="group-settings" id="custom-enrollment-email-settings"><!-- IMPORTANT -->
+              <section class="group-settings">
+                <p>
+                  ${_("Message for students who enroll {strong_start}before the start date{strong_end}").format(strong_start="<strong>", strong_end="</strong>")}
+                  <a class="send-test-email" id='test_email_pre' title="${_('Send me a copy of this via email')}" href="#">${_("Send me a test email")}</a>
+                  <a class="fill-default-email" id='fill_default_email_pre' title="${_('Reset to default content')}" href="#">${_("Reset to default content")}</a>
+                </p>
+                <ol class="list-input">
+                  <li class="field text">
+                    <p>
+                      <label for="pre-enrollment-email-subject">${_("Subject of the Email")}</label>
+                      <input type="text" class='text subject' id="pre-enrollment-email-subject"/>
+                    </p>
+                    <p>
+                      <label for="pre-enrollment-email">${_("Body of the Email")}</label>
+                      <textarea class="tinymce text-editor" id="pre-enrollment-email"></textarea>
+                      <span class="tip tip-stacked">${_("This email will be sent to any student who enrolls in the course before its start date.")}</span>
+                    </p>
+                  </li>
+                </ol>
+              </section>
+              <section class="group-settings">
+                <p>
+                  ${_("Message for students who enroll {strong_start}on or after the start date{strong_end}").format(strong_start="<strong>", strong_end="</strong>")}
+                  <a class="send-test-email" id='test_email_post' title="${_('Send me a copy of this via email')}" href="#">${_("Send me a test email")}</a>
+                  <a class="fill-default-email" id='fill_default_email_post' title="${_('Reset to default content')}" href="#">${_("Reset to default content")}</a>
+                </p>
+                <ol class="list-input">
+                  <li class="field text">
+                    <p>
+                      <label for="post-enrollment-email-subject">${_("Subject of the Email")}</label>
+                      <input type="text" class='text subject' id="post-enrollment-email-subject"/>
+                    </p>
+                    <p>
+                      <label for="post-enrollment-email">${_("Body of the Email")}</label>
+                      <textarea class="tinymce text-editor" id="post-enrollment-email"></textarea>
+                      <span class="tip tip-stacked">${_("This email will be sent to any student who enrolls in the course after its start date.")}</span>
+                    </p>
+                  </li>
+                </ol>
+              </section>
+            </section>
+          </section>
+        </section>
 
           % if about_page_editable:
             <hr class="divide" />
@@ -372,5 +384,7 @@ require(["domReady!", "jquery", "js/models/settings/course_details", "js/views/s
      </div>
     </aside>
   </section>
+  <div id="default_pre_enrollment_email_template" style="display:none;">${default_pre_template}</div>
+  <div id="default_post_enrollment_email_template" style="display:none;">${default_post_template}</div>
 </div>
 </%block>

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -91,6 +91,7 @@ urlpatterns += patterns(
     url(r'^settings/details/{}$'.format(settings.COURSE_KEY_PATTERN), 'settings_handler'),
     url(r'^settings/grading/{}(/)?(?P<grader_index>\d+)?$'.format(settings.COURSE_KEY_PATTERN), 'grading_handler'),
     url(r'^settings/advanced/{}$'.format(settings.COURSE_KEY_PATTERN), 'advanced_settings_handler'),
+    url(r'^settings/send_test_enrollment_email$', 'send_test_enrollment_email', name='send_test_enrollment_email'),
     url(r'^textbooks/{}$'.format(settings.COURSE_KEY_PATTERN), 'textbooks_list_handler'),
     url(r'^textbooks/{}/(?P<textbook_id>\d[^/]*)$'.format(settings.COURSE_KEY_PATTERN), 'textbooks_detail_handler'),
 )

--- a/common/djangoapps/student/tests/test_email.py
+++ b/common/djangoapps/student/tests/test_email.py
@@ -88,19 +88,9 @@ class EnrollmentEmailTests(TestCase):
     def test_custom_enrollment_email_sent(self):
         """ Test sending of enrollment emails when enable_default_enrollment_email setting is disabled. """
         self.course.enable_enrollment_email = True
-        self.course.enable_default_enrollment_email = False
         email_result = self.send_enrollment_email()
         self.assertNotIn('email_did_fire', email_result)
         self.assertIn('is_success', email_result)
-
-    def test_default_enrollment_email_sent(self):
-        """ Test sending of enrollment emails when enable_default_enrollment_email setting is enabled. """
-        self.course.enable_enrollment_email = True
-        self.course.enable_default_enrollment_email = True
-        email_result = self.send_enrollment_email()
-        self.assertNotIn('email_did_fire', email_result)
-        self.assertIn('is_success', email_result)
-
 
 @patch('student.views.render_to_string', Mock(side_effect=mock_render_to_string, autospec=True))
 @patch('django.contrib.auth.models.User.email_user')

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -171,7 +171,6 @@ class CourseFields(object):
 
     wiki_slug = String(help="Slug that points to the wiki for this course", scope=Scope.content)
     enable_enrollment_email = Boolean(help="Whether to send notification email upon enrollment or not", default=False, scope=Scope.settings)
-    enable_default_enrollment_email = Boolean(help="Whether to use default enrollment email for enrollment notification", default=True, scope=Scope.settings)
     enrollment_start = Date(help="Date that enrollment for this class is opened", scope=Scope.settings)
     enrollment_end = Date(help="Date that enrollment for this class is closed", scope=Scope.settings)
     start = Date(help="Start time when this module is visible",

--- a/common/templates/emails/default_post_enrollment_message.txt
+++ b/common/templates/emails/default_post_enrollment_message.txt
@@ -1,0 +1,19 @@
+Hi there!
+
+Thank you for enrolling in a Stanford Online course.  You are receiving this
+email from the Stanford Online Team as a confirmation that you have
+successfully enrolled in one of our online courses.  Your chosen course will
+now appear on your Stanford Online (https://class.stanford.edu/dashboard)
+dashboard.  This course is already under way, so make sure to sign in
+(https://class.stanford.edu/login) and click "View Course" from your dashboard
+in order to get started.  Doing this will take you to the Course Info page for
+more information.
+
+Have more questions?  Please visit the course's About page or review some
+frequently asked questions in the Help Center at
+https://stanfordonline.zendesk.com/hc/en-us.  Or, send the Stanford Online
+course support team a message by clicking on the Help tab that displays on all
+https://class.stanford.edu pages.
+
+See you soon!
+The Stanford Online Team

--- a/common/templates/emails/default_pre_enrollment_message.txt
+++ b/common/templates/emails/default_pre_enrollment_message.txt
@@ -1,0 +1,22 @@
+Hi there!
+
+Thank you for enrolling in a Stanford Online course.  You are receiving this
+email from the Stanford Online Team as a confirmation that you have
+successfully enrolled in one of our online courses.  Your chosen course will
+now appear on your Stanford Online (https://class.stanford.edu/dashboard)
+dashboard.  As it has not yet started, you'll notice that it isn't yet possible
+to access the course site.  Once the course begins, the course team will send
+out a welcome email to everyone enrolled with more information.
+
+For the time being, you can return to the course listing page at
+https://class.stanford.edu/courses and click to access your course's About page
+for more information, such as when the course will start, and what topics will
+be covered in the course.
+
+Have more questions?  Please visit the Help Center at
+https://stanfordonline.zendesk.com/hc/en-us, or send the Stanford Online course
+support team a message by clicking on the Help tab that displays on all
+https://class.stanford.edu pages.
+
+See you soon!
+The Stanford Online Team


### PR DESCRIPTION
@jrbl @caesar2164 

Fixed enrollment email UI in Studio. The list of changes is as follows:
    - Test Email functionality: can now send yourself a test email from studio
    - Set default template button: can now click a button to replace email
        with the default template
    - UI changes: html ordering and structuring
                  Got rid of enable_default_email button. Pushed this feature
                  to the default template button

Things to note:
    - default template is stanford-specific.
    - minor test changes (since enable_default_email field is gone now)

![screen shot 2014-07-30 at 12 48 48 pm](https://cloud.githubusercontent.com/assets/3598201/3755213/a65ef2ce-1822-11e4-9b63-d01e16be444f.png)
![screen shot 2014-07-30 at 12 49 07 pm](https://cloud.githubusercontent.com/assets/3598201/3755214/a65f7c30-1822-11e4-8c06-cfdc32c476af.png)
![screen shot 2014-07-30 at 12 48 28 pm](https://cloud.githubusercontent.com/assets/3598201/3755215/a66022e8-1822-11e4-8005-c7200f417886.png)
