### PR TITLE
Cleaning up messes from hurried upstream merge

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_utilities.py
+++ b/cms/djangoapps/contentstore/tests/test_utilities.py
@@ -40,7 +40,6 @@ class UtilitiesTestCase(CourseTestCase):
         response = self.client.get(self.utilities_url)
         self.assertContains(response, "Bulk Operations")
         # Verify expansion of action URL happened.
-        #self.assertContains(response, '/utility/captions/slashes:mitX+333+Utilities_Course')
         self.assertContains(response, '/utility/captions/mitX/333/Utilities_Course')
         # Verify persisted utility does NOT have expanded URL.
         utility_0 = self.get_persisted_utilities()[0]
@@ -105,7 +104,6 @@ class UtilitiesTestCase(CourseTestCase):
             # Verify no side effect in the original list.
             self.assertEqual(get_action_url(utility, index), stored)
 
-        #test_expansion(settings.COURSE_UTILITIES[0], 0, 'utility_captions_handler', '/utility/captions/slashes:mitX+333+Utilities_Course')
         test_expansion(settings.COURSE_UTILITIES[0], 0, 'utility_captions_handler', '/utility/captions/mitX/333/Utilities_Course')
 
 

--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -66,6 +66,7 @@ else:
         'concept',  # Concept mapper. See https://github.com/pmitros/ConceptXBlock
         'done',  # Lets students mark things as done. See https://github.com/pmitros/DoneXBlock
         'audio',  # Embed an audio file. See https://github.com/pmitros/AudioXBlock
+        'edx_sga', # that weird grading xblock thing - remove this next merge
         SPLIT_TEST_COMPONENT_TYPE,  # Adds A/B test support
         'recommender', # Crowdsourced recommender. Prototype by dli&pmitros. Intended for roll-out in one place in one course. 
         'ooyala-player',

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -170,11 +170,6 @@ def _has_access_course_desc(user, action, course):
         else:
             reg_method_ok = True  # if not using this access check, it's always OK.
 
-        #if reg_method_ok and within_enrollment_period():
-        #    # in enrollment period, so any user is allowed to enroll.
-        #    debug("Allow: in enrollment period")
-        #    return True
-
         now = datetime.now(UTC())
         start = course.enrollment_start or datetime.min.replace(tzinfo=pytz.UTC)
         end = course.enrollment_end or datetime.max.replace(tzinfo=pytz.UTC)


### PR DESCRIPTION
@stvstnfrd these are the fixes we talked about. I remove the commented-out lines from access.py and the tests, and I restore 'edx_sga' to the CMS advanced components. This should put us ahead of current release by the difference of the commented-out-line removals.
