### PR TITLE
Fix Enroll-email subject containing newline

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -478,6 +478,7 @@ def send_test_enrollment_email(request):
     user = request.user
     from_address = microsite.get_value('email_from_address', settings.DEFAULT_FROM_EMAIL)
     subject = request.POST.get('subject')
+    subject = ''.join(subject.splitlines())
     message = request.POST.get('message')
 
     try:

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -747,6 +747,7 @@ def notify_enrollment_by_email(course, user, request):
                 subject = get_course_about_section(course, 'pre_enrollment_email_subject')
                 message = get_course_about_section(course, 'pre_enrollment_email')
 
+            subject = ''.join(subject.splitlines())
             user.email_user(subject, message, from_address)
 
         except Exception:


### PR DESCRIPTION
Fixing a bug where email subjects contain newlines.. @stvstnfrd 
