### PR TITLE
Fix json_update_videos()

### DIFF
--- a/cms/djangoapps/contentstore/views/utilities/captions.py
+++ b/cms/djangoapps/contentstore/views/utilities/captions.py
@@ -86,7 +86,7 @@ def json_update_videos(request, locations):
         try:
             #update transcripts
             item = modulestore().get_item(key)
-            download_youtube_subs({1.0: item.youtube_id_1_0}, item, settings)
+            download_youtube_subs(item.youtube_id_1_0, item, settings)
 
             #get new status
             videos = {'youtube': item.youtube_id_1_0}


### PR DESCRIPTION
```
commit (1f5c95b) to transcript_utils.py changed the sig of download_youtube_subs from 
    def download_youtube_subs(youtube_subs, item, settings):
    to:
    def download_youtube_subs(youtube_id, video_descriptor, settings):

    hence taking a video id instead of a dict.

   This broke the download captions feature from the utilities page.
```
