### PR TITLE
make help center link a visible button

### DIFF
--- a/lms/templates/help_modal.html
+++ b/lms/templates/help_modal.html
@@ -48,18 +48,19 @@
     </p>
 % endif
 
-    <p>${_('Have <strong>general questions about {platform_name}</strong>? You can find lots of helpful information in the {platform_name} {link_start}Help Center{link_end}.').format(
-        link_start='<a href="{url}" target="_blank">'.format(
-          url='https://stanfordonline.zendesk.com/hc/en-us'
-        ),
-        link_end='</a>',
-        platform_name=platform_name)}
-      </p>
+    <p>${_('Have <strong>general questions about {platform_name}</strong>? You can find lots of helpful information in the {platform_name} Help Center.').format(platform_name=platform_name)}</p>
+	
+	<div class="help-buttons">
+	  <a id="help-center-button" href="{url}" target="_blank">
+		${_('Access the Help Center')}
+	  </a>
+	</div>
 
-    <p>${_('Have a <strong>question about something specific</strong>? You can contact the {platform_name} general support team directly:').format(
+	<hr>
+
+    <p>${_("Can't find an answer to your question? You can contact the {platform_name} general support team directly:").format(
         platform_name=platform_name
       )}</p>
-    <hr>
 
     <div class="help-buttons">
       <a href="#" id="feedback_link_problem">${_('Report a problem')}</a>


### PR DESCRIPTION
@stvstnfrd & @sefk - change to help modal to make the link to the help center a button. (this PR is in conjunction with the [theme one](https://github.com/Stanford-Online/stanford-theme/pull/1))

![screen shot 2014-08-14 at 4 11 03 pm](https://cloud.githubusercontent.com/assets/3364609/3928324/51c0b2ec-2408-11e4-91d9-1841bc7b37a6.png)
