### PR TITLE
Bump edx-submissions to v0.0.6

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -134,4 +134,4 @@ git+https://github.com/mfogel/django-settings-context-processor.git
 git+https://github.com/mitocw/django-cas.git
 
 # edX packages
-edx-submissions==0.0.3
+edx-submissions==0.0.6


### PR DESCRIPTION
This is required following our update to a new version of ORA2.

@sefk @dcadams
