### PR TITLE
direct access: exclude non-registered from enrollments

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -701,9 +701,13 @@ class CourseEnrollment(models.Model):
         Returns the count of active enrollments in a course.
 
         'course_id' is the course_id to return enrollments
+        Direct access: don't include non-registered enrollments in counts.
         """
-        enrollment_number = CourseEnrollment.objects.filter(course_id=course_id, is_active=1).count()
-
+        enrollment_number = CourseEnrollment.objects.filter(
+            course_id=course_id,
+            is_active=1,
+            user__profile__nonregistered=0,
+        ).count()
         return enrollment_number
 
     @classmethod

--- a/lms/djangoapps/analytics/basic.py
+++ b/lms/djangoapps/analytics/basic.py
@@ -24,10 +24,13 @@ def enrolled_students_features(course_id, features):
         {'username': 'username2', 'first_name': 'firstname2'}
         {'username': 'username3', 'first_name': 'firstname3'}
     ]
+
+    Direct access: don't include non-registered enrollments in result.
     """
     students = User.objects.filter(
         courseenrollment__course_id=course_id,
         courseenrollment__is_active=1,
+        profile__nonregistered=0,
     ).order_by('username').select_related('profile')
 
     def extract_student(student, features):


### PR DESCRIPTION
Direct access introduces a bunch of fake course enrollments.  We
don't want to include those in the counts of students enrolled in
the course, nor in the list of students dumped out in the course
roster.

Note the use of the "extra" to add a join and where clause to the
query.  Becuase there is no foreign key from User to UserProfile,
just the other way around, we can't use the ORM to generate these
joins for us.  This is what you'd wish would work, but doesn't.

```
exclude(user__userprofile__nonregistered=1)
```

Hence we're back to this annoying "extra" business.

@jbau review pls.
