### PR TITLE
NOOP on setupFullScreenImage

### DIFF
--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -322,6 +322,11 @@
       <%static:include path="js/system-feedback.underscore" />
     </script>
 
+    <script type="text/javascript">
+        // TODO: Remove this!
+        // This is a stop-gap "fix" to silence a Studio exception.
+        function setupFullScreenImage(){}
+    </script>
 
     % if context_course:
         <script type="text/javascript">


### PR DESCRIPTION
Something appears to have changed, with regards to JavaScript loading
via Studio. The function in-question, `setupFullScreenImage`, still
behaves as intended in LMS. However, it fails in Studio despite being
(seemingly?) present in the compiled `cms-modules-xxx.js` file which is
loaded into Studio pages.

This commit defines an in-line NOOP definition of the function, to
ensure that it is always defined in Studio. The feature degrades
gracefully and will now simply render as an image link that leads
directly to the image URL.

Note: LMS is unaffected by both the problem and temporary solution.

This commit must be reverted once we diagnose and resolve the original
issue.
