### PR TITLE
Restore settings.FEATURES for Django templates

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -383,6 +383,9 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     # Hack to get required link URLs to password reset templates
     'edxmako.shortcuts.marketing_link_context_processor',
 
+    # Include TEMPLATE_VISIBLE_SETTINGS in templates
+    'settings_context_processor.context_processors.settings',
+
     # Allows the open edX footer to be leveraged in Django Templates.
     'edxmako.shortcuts.open_source_footer_context_processor',
 
@@ -1430,6 +1433,12 @@ MKTG_URL_LINK_MAP = {
     # Verified Certificates
     'WHAT_IS_VERIFIED_CERT': 'verified-certificate',
 }
+
+######################### VISIBLE SETTINGS ###########################
+# These settings' values will be exposed to all templates
+TEMPLATE_VISIBLE_SETTINGS = [
+    'FEATURES',
+]
 
 ############################### CHAT ################################
 JABBER = {}


### PR DESCRIPTION
This was removed following the recent merge from upstream. It caused
certain pages (namely the Wiki) to be styled incorrectly (using edX's
default styling).

This fix is not perfect, as some pages now inherit edX styles where they
should not (password reset). This is deemed as acceptable, as it is a
much less jarring user experience.

TODO: Fix these noted exceptions
TODO: edX should move all instance-specific styling to their own theme.
