### PR TITLE
Support and tests for adding a reset button to units

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_unit_page.py
+++ b/cms/djangoapps/contentstore/views/tests/test_unit_page.py
@@ -6,6 +6,8 @@ from contentstore.views.tests.utils import StudioPageTestCase
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.factories import ItemFactory
 from xmodule.x_module import STUDENT_VIEW
+from courseware.tests import render_to_string
+from courseware.tests import XModuleRenderingTestBase
 
 
 class UnitPageTestCase(StudioPageTestCase):
@@ -57,3 +59,34 @@ class UnitPageTestCase(StudioPageTestCase):
                            category='html', display_name='grandchild')
         draft_child_container = self.store.get_item(child_container.location)
         self.validate_preview_html(draft_child_container, STUDENT_VIEW, can_add=False)
+
+
+class RenderingTest(XModuleRenderingTestBase):
+    def test_reset_button_shows(self):
+        context = {
+            'answer_available': True,
+            'attempts_allowed': 2,
+            'attempts_used': 0,
+            'check_button': u'Submit',
+            'check_button_checking': u'Checking...',
+            'end_time_to_display': None,
+            'id': u'1',
+            'problem': {
+                'html': "",
+                'name': u'Checkboxes',
+                'weight': None
+            },
+            'problem_is_timed': False,
+            'reset_button': True,
+            'save_button': True,
+            'start_time': None
+        }
+
+        renderer = self.new_module_runtime()
+        html = renderer.render_template("problem.html", context, None, namespace="lms.main")
+        resetbutton = '<input class="reset" type="button" value="Reset" />'
+        self.assertIn(resetbutton, html)
+
+        context['reset_button'] = False
+        html2 = renderer.render_template("problem.html", context, None, namespace="lms.main")
+        self.assertNotIn(resetbutton, html2)

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -29,6 +29,7 @@ from xblock.fields import Scope, String, Boolean, Dict, Integer, Float
 from .fields import Timedelta, Date
 from django.utils.timezone import UTC
 from .util.duedate import get_extended_due_date
+from capa_base_constants import RANDOMIZATION, SHOWANSWER
 
 log = logging.getLogger("edx.courseware")
 
@@ -63,9 +64,9 @@ class Randomization(String):
     """
     def from_json(self, value):
         if value in ("", "true"):
-            return "always"
+            return RANDOMIZATION.ALWAYS
         elif value == "false":
-            return "per_student"
+            return RANDOMIZATION.PER_STUDENT
         return value
 
     to_json = from_json
@@ -103,15 +104,16 @@ class CapaFields(object):
     max_attempts = Integer(
         display_name=_("Maximum Attempts"),
         help=_("Defines the number of times a student can try to answer this problem. "
-              "If the value is not set, infinite attempts are allowed."),
+               "If the value is not set, infinite attempts are allowed."),
         values={"min": 0}, scope=Scope.settings
     )
+
     due = Date(help=_("Date that this problem is due by"), scope=Scope.settings)
     extended_due = Date(
         help=_("Date that this problem is due by for a particular student. This "
-             "can be set by an instructor, and will override the global due "
-             "date if it is set to a date that is later than the global due "
-             "date."),
+               "can be set by an instructor, and will override the global due "
+               "date if it is set to a date that is later than the global due "
+               "date."),
         default=None,
         scope=Scope.user_state,
     )
@@ -122,36 +124,42 @@ class CapaFields(object):
     showanswer = String(
         display_name=_("Show Answer"),
         help=_("Defines when to show the answer to the problem. "
-              "A default value can be set in Advanced Settings."),
+               "A default value can be set in Advanced Settings."),
         scope=Scope.settings,
-        default="finished",
+        default=SHOWANSWER.FINISHED,
         values=[
-            {"display_name": _("Always"), "value": "always"},
-            {"display_name": _("Answered"), "value": "answered"},
-            {"display_name": _("Attempted"), "value": "attempted"},
-            {"display_name": _("Closed"), "value": "closed"},
-            {"display_name": _("Finished"), "value": "finished"},
-            {"display_name": _("Correct or Past Due"), "value": "correct_or_past_due"},
-            {"display_name": _("Past Due"), "value": "past_due"},
-            {"display_name": _("Never"), "value": "never"}]
+            {"display_name": _("Always"), "value": SHOWANSWER.ALWAYS},
+            {"display_name": _("Answered"), "value": SHOWANSWER.ANSWERED},
+            {"display_name": _("Attempted"), "value": SHOWANSWER.ATTEMPTED},
+            {"display_name": _("Closed"), "value": SHOWANSWER.CLOSED},
+            {"display_name": _("Finished"), "value": SHOWANSWER.FINISHED},
+            {"display_name": _("Correct or Past Due"), "value": SHOWANSWER.CORRECT_OR_PAST_DUE},
+            {"display_name": _("Past Due"), "value": SHOWANSWER.PAST_DUE},
+            {"display_name": _("Never"), "value": SHOWANSWER.NEVER}]
     )
     force_save_button = Boolean(
         help=_("Whether to force the save button to appear on the page"),
         scope=Scope.settings,
         default=False
     )
+    show_reset_button = Boolean(
+        display_name=_("Show Reset Button"),
+        help=_('Determines whether a "Reset" button is shown so the user may reset their answer.'),
+        scope=Scope.settings,
+        default=True
+    )
     rerandomize = Randomization(
         display_name=_("Randomization"),
         help=_("Defines how often inputs are randomized when a student loads the problem. "
-             "This setting only applies to problems that can have randomly generated numeric values. "
-             "A default value can be set in Advanced Settings."),
-        default="never",
+               "This setting only applies to problems that can have randomly generated numeric values. "
+               "A default value can be set in Advanced Settings."),
+        default=RANDOMIZATION.NEVER,
         scope=Scope.settings,
         values=[
-            {"display_name": _("Always"), "value": "always"},
-            {"display_name": _("On Reset"), "value": "onreset"},
-            {"display_name": _("Never"), "value": "never"},
-            {"display_name": _("Per Student"), "value": "per_student"}
+            {"display_name": _("Always"), "value": RANDOMIZATION.ALWAYS},
+            {"display_name": _("On Reset"), "value": RANDOMIZATION.ONRESET},
+            {"display_name": _("Never"), "value": RANDOMIZATION.NEVER},
+            {"display_name": _("Per Student"), "value": RANDOMIZATION.PER_STUDENT}
         ]
     )
     data = String(help=_("XML data for the problem"), scope=Scope.content, default="<problem></problem>")
@@ -173,7 +181,7 @@ class CapaFields(object):
     weight = Float(
         display_name=_("Problem Weight"),
         help=_("Defines the number of points each problem is worth. "
-              "If the value is not set, each response field in the problem is worth one point."),
+               "If the value is not set, each response field in the problem is worth one point."),
         values={"min": 0, "step": .1},
         scope=Scope.settings
     )
@@ -257,7 +265,7 @@ class CapaMixin(CapaFields):
                     tb=cgi.escape(
                         u''.join(['Traceback (most recent call last):\n'] +
                         traceback.format_tb(sys.exc_info()[2])))
-                    )
+                )
                 # create a dummy problem with error message instead of failing
                 problem_text = (u'<problem><text><span class="inline-error">'
                                 u'Problem {url} has an error:</span>{msg}</text></problem>'.format(
@@ -277,9 +285,9 @@ class CapaMixin(CapaFields):
         """
         Choose a new seed.
         """
-        if self.rerandomize == 'never':
+        if self.rerandomize == RANDOMIZATION.NEVER:
             self.seed = 1
-        elif self.rerandomize == "per_student" and hasattr(self.runtime, 'seed'):
+        elif self.rerandomize == RANDOMIZATION.PER_STUDENT and hasattr(self.runtime, 'seed'):
             # see comment on randomization_bin
             self.seed = randomization_bin(self.runtime.seed, unicode(self.location).encode('utf-8'))
         else:
@@ -461,7 +469,7 @@ class CapaMixin(CapaFields):
         """
         Return True/False to indicate whether to show the "Check" button.
         """
-        submitted_without_reset = (self.is_submitted() and self.rerandomize == "always")
+        submitted_without_reset = (self.is_submitted() and self.rerandomize == RANDOMIZATION.ALWAYS)
 
         # If the problem is closed (past due / too many attempts)
         # then we do NOT show the "check" button
@@ -478,19 +486,20 @@ class CapaMixin(CapaFields):
         """
         is_survey_question = (self.max_attempts == 0)
 
-        if self.rerandomize in ["always", "onreset"]:
-
-            # If the problem is closed (and not a survey question with max_attempts==0),
-            # then do NOT show the reset button.
-            # If the problem hasn't been submitted yet, then do NOT show
-            # the reset button.
-            if (self.closed() and not is_survey_question) or not self.is_submitted():
+        # If the problem is closed (and not a survey question with max_attempts==0),
+        # then do NOT show the reset button.
+        if (self.closed() and not is_survey_question):
                 return False
-            else:
-                return True
-        # Only randomized problems need a "reset" button
-        else:
+
+        # Never show the button if the problem is correct
+        if self.is_correct():
             return False
+
+        # Button only shows up for randomized problems if the question has been submitted
+        if self.rerandomize in [RANDOMIZATION.ALWAYS, RANDOMIZATION.ONRESET] and self.is_submitted():
+            return True
+        else:
+            return self.show_reset_button
 
     def should_show_save_button(self):
         """
@@ -504,7 +513,7 @@ class CapaMixin(CapaFields):
             return not self.closed()
         else:
             is_survey_question = (self.max_attempts == 0)
-            needs_reset = self.is_submitted() and self.rerandomize == "always"
+            needs_reset = self.is_submitted() and self.rerandomize == RANDOMIZATION.ALWAYS
 
             # If the student has unlimited attempts, and their answers
             # are not randomized, then we do not need a save button
@@ -518,7 +527,7 @@ class CapaMixin(CapaFields):
             # In those cases. the if statement below is false,
             # and the save button can still be displayed.
             #
-            if self.max_attempts is None and self.rerandomize != "always":
+            if self.max_attempts is None and self.rerandomize != RANDOMIZATION.ALWAYS:
                 return False
 
             # If the problem is closed (and not a survey question with max_attempts==0),
@@ -640,7 +649,6 @@ class CapaMixin(CapaFields):
         if self.due and end_time_to_display:
             end_time_to_display = min(self.due, end_time_to_display)
 
-
         content = {
             'name': self.display_name_with_default,
             'html': html,
@@ -743,28 +751,28 @@ class CapaMixin(CapaFields):
         """
         if self.showanswer == '':
             return False
-        elif self.showanswer == "never":
+        elif self.showanswer == SHOWANSWER.NEVER:
             return False
         elif self.runtime.user_is_staff:
             # This is after the 'never' check because admins can see the answer
             # unless the problem explicitly prevents it
             return True
-        elif self.showanswer == 'attempted':
+        elif self.showanswer == SHOWANSWER.ATTEMPTED:
             return self.attempts > 0
-        elif self.showanswer == 'answered':
+        elif self.showanswer == SHOWANSWER.ANSWERED:
             # NOTE: this is slightly different from 'attempted' -- resetting the problems
             # makes lcp.done False, but leaves attempts unchanged.
             return self.lcp.done
-        elif self.showanswer == 'closed':
+        elif self.showanswer == SHOWANSWER.CLOSED:
             return self.closed()
-        elif self.showanswer == 'finished':
+        elif self.showanswer == SHOWANSWER.FINISHED:
             return self.closed() or self.is_correct()
 
-        elif self.showanswer == 'correct_or_past_due':
+        elif self.showanswer == SHOWANSWER.CORRECT_OR_PAST_DUE:
             return self.is_correct() or self.is_past_due()
-        elif self.showanswer == 'past_due':
+        elif self.showanswer == SHOWANSWER.PAST_DUE:
             return self.is_past_due()
-        elif self.showanswer == 'always':
+        elif self.showanswer == SHOWANSWER.ALWAYS:
             return True
 
         return False
@@ -998,7 +1006,7 @@ class CapaMixin(CapaFields):
             raise NotFoundError(_("Problem is closed."))
 
         # Problem submitted. Student should reset before checking again
-        if self.done and self.rerandomize == "always":
+        if self.done and self.rerandomize == RANDOMIZATION.ALWAYS:
             event_info['failure'] = 'unreset'
             self.track_function_unmask('problem_check_fail', event_info)
             if dog_stats_api:
@@ -1252,7 +1260,7 @@ class CapaMixin(CapaFields):
             # was presented to the user, with values interpolated etc, but that can be done
             # later if necessary.
             variant = ''
-            if self.rerandomize != 'never':
+            if self.rerandomize != RANDOMIZATION.NEVER:
                 variant = self.seed
 
             is_correct = correct_map.is_correct(input_id)
@@ -1379,7 +1387,7 @@ class CapaMixin(CapaFields):
 
         # Problem submitted. Student should reset before saving
         # again.
-        if self.done and self.rerandomize == "always":
+        if self.done and self.rerandomize == RANDOMIZATION.ALWAYS:
             event_info['failure'] = 'done'
             self.track_function_unmask('save_problem_fail', event_info)
             return {
@@ -1403,7 +1411,7 @@ class CapaMixin(CapaFields):
     def reset_problem(self, _data):
         """
         Changes problem state to unfinished -- removes student answers,
-        and causes problem to rerender itself.
+        causes problem to rerender itself if randomization is enabled.
 
         Returns a dictionary of the form:
           {'success': True/False,
@@ -1426,7 +1434,7 @@ class CapaMixin(CapaFields):
                 'error': _("Problem is closed."),
             }
 
-        if not self.done:
+        if not self.is_submitted():
             event_info['failure'] = 'not_done'
             self.track_function_unmask('reset_problem_fail', event_info)
             return {
@@ -1435,7 +1443,7 @@ class CapaMixin(CapaFields):
                 'error': _("Refresh the page and make an attempt before resetting."),
             }
 
-        if self.rerandomize in ["always", "onreset"]:
+        if self.is_submitted() and self.rerandomize in [RANDOMIZATION.ALWAYS, RANDOMIZATION.ONRESET]:
             # Reset random number generator seed.
             self.choose_new_seed()
 

--- a/common/lib/xmodule/xmodule/capa_base_constants.py
+++ b/common/lib/xmodule/xmodule/capa_base_constants.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""
+Constants for capa_base problems
+"""
+
+
+class SHOWANSWER:
+    ALWAYS = "always"
+    ANSWERED = "answered"
+    ATTEMPTED = "attempted"
+    CLOSED = "closed"
+    FINISHED = "finished"
+    CORRECT_OR_PAST_DUE = "correct_or_past_due"
+    PAST_DUE = "past_due"
+    NEVER = "never"
+
+
+class RANDOMIZATION:
+    ALWAYS = "always"
+    ONRESET = "onreset"
+    NEVER = "never"
+    PER_STUDENT = "per_student"

--- a/common/lib/xmodule/xmodule/modulestore/inheritance.py
+++ b/common/lib/xmodule/xmodule/modulestore/inheritance.py
@@ -154,6 +154,14 @@ class InheritanceMixin(XBlockMixin):
         scope=Scope.settings
     )
 
+    show_reset_button = Boolean(
+        display_name=_("Show Reset Button for Problems"),
+        help=_("Enter true or false. If true, problems default to displaying a 'Reset' button. This value may be "
+               "overriden in each problem's settings. Existing problems are unaffected."),
+        scope=Scope.settings,
+        default=True
+    )
+
 
 def compute_inherited_metadata(descriptor):
     """Given a descriptor, traverse all of its descendants and do metadata

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -31,6 +31,7 @@ from xblock.fields import ScopeIds
 from . import get_test_system
 from pytz import UTC
 from capa.correctmap import CorrectMap
+from ..capa_base_constants import RANDOMIZATION
 
 
 class CapaFactory(object):
@@ -517,7 +518,7 @@ class CapaModuleTest(unittest.TestCase):
         self.assertEqual(module.attempts, 3)
 
     def test_check_problem_resubmitted_with_randomize(self):
-        rerandomize_values = ['always', 'true']
+        rerandomize_values = [RANDOMIZATION.ALWAYS, 'true']
 
         for rerandomize in rerandomize_values:
             # Randomize turned on
@@ -535,7 +536,9 @@ class CapaModuleTest(unittest.TestCase):
             self.assertEqual(module.attempts, 0)
 
     def test_check_problem_resubmitted_no_randomize(self):
-        rerandomize_values = ['never', 'false', 'per_student']
+        rerandomize_values = [RANDOMIZATION.NEVER,
+                              'false',
+                              RANDOMIZATION.PER_STUDENT]
 
         for rerandomize in rerandomize_values:
             # Randomize turned off
@@ -789,7 +792,7 @@ class CapaModuleTest(unittest.TestCase):
 
     def test_reset_problem_closed(self):
         # pre studio default
-        module = CapaFactory.create(rerandomize="always")
+        module = CapaFactory.create(rerandomize=RANDOMIZATION.ALWAYS)
 
         # Simulate that the problem is closed
         with patch('xmodule.capa_module.CapaModule.closed') as mock_closed:
@@ -923,7 +926,7 @@ class CapaModuleTest(unittest.TestCase):
     def test_save_problem_submitted_with_randomize(self):
 
         # Capa XModule treats 'always' and 'true' equivalently
-        rerandomize_values = ['always', 'true']
+        rerandomize_values = [RANDOMIZATION.ALWAYS, 'true']
 
         for rerandomize in rerandomize_values:
             module = CapaFactory.create(rerandomize=rerandomize, done=True)
@@ -938,7 +941,9 @@ class CapaModuleTest(unittest.TestCase):
     def test_save_problem_submitted_no_randomize(self):
 
         # Capa XModule treats 'false' and 'per_student' equivalently
-        rerandomize_values = ['never', 'false', 'per_student']
+        rerandomize_values = [RANDOMIZATION.NEVER,
+                              'false',
+                              RANDOMIZATION.PER_STUDENT]
 
         for rerandomize in rerandomize_values:
             module = CapaFactory.create(rerandomize=rerandomize, done=True)
@@ -1041,7 +1046,7 @@ class CapaModuleTest(unittest.TestCase):
         # If user submitted a problem but hasn't reset,
         # do NOT show the check button
         # Note:  we can only reset when rerandomize="always" or "true"
-        module = CapaFactory.create(rerandomize="always", done=True)
+        module = CapaFactory.create(rerandomize=RANDOMIZATION.ALWAYS, done=True)
         self.assertFalse(module.should_show_check_button())
 
         module = CapaFactory.create(rerandomize="true", done=True)
@@ -1055,13 +1060,13 @@ class CapaModuleTest(unittest.TestCase):
         # and we do NOT have a reset button, then we can show the check button
         # Setting rerandomize to "never" or "false" ensures that the reset button
         # is not shown
-        module = CapaFactory.create(rerandomize="never", done=True)
+        module = CapaFactory.create(rerandomize=RANDOMIZATION.NEVER, done=True)
         self.assertTrue(module.should_show_check_button())
 
         module = CapaFactory.create(rerandomize="false", done=True)
         self.assertTrue(module.should_show_check_button())
 
-        module = CapaFactory.create(rerandomize="per_student", done=True)
+        module = CapaFactory.create(rerandomize=RANDOMIZATION.PER_STUDENT, done=True)
         self.assertTrue(module.should_show_check_button())
 
     def test_should_show_reset_button(self):
@@ -1076,31 +1081,33 @@ class CapaModuleTest(unittest.TestCase):
         module = CapaFactory.create(attempts=attempts, max_attempts=attempts, done=True)
         self.assertFalse(module.should_show_reset_button())
 
-        # If we're NOT randomizing, then do NOT show the reset button
-        module = CapaFactory.create(rerandomize="never", done=True)
-        self.assertFalse(module.should_show_reset_button())
-
-        # If we're NOT randomizing, then do NOT show the reset button
-        module = CapaFactory.create(rerandomize="per_student", done=True)
-        self.assertFalse(module.should_show_reset_button())
-
-        # If we're NOT randomizing, then do NOT show the reset button
-        module = CapaFactory.create(rerandomize="false", done=True)
-        self.assertFalse(module.should_show_reset_button())
-
-        # If the user hasn't submitted an answer yet,
-        # then do NOT show the reset button
-        module = CapaFactory.create(done=False)
-        self.assertFalse(module.should_show_reset_button())
-
         # pre studio default value, DO show the reset button
-        module = CapaFactory.create(rerandomize="always", done=True)
+        module = CapaFactory.create(rerandomize=RANDOMIZATION.ALWAYS, done=True)
         self.assertTrue(module.should_show_reset_button())
 
         # If survey question for capa (max_attempts = 0),
         # DO show the reset button
-        module = CapaFactory.create(rerandomize="always", max_attempts=0, done=True)
+        module = CapaFactory.create(rerandomize=RANDOMIZATION.ALWAYS, max_attempts=0, done=True)
         self.assertTrue(module.should_show_reset_button())
+
+        # If the question is not correct
+        # DO show the reset button
+        module = CapaFactory.create(rerandomize=RANDOMIZATION.ALWAYS, max_attempts=0, done=True, correct=False)
+        self.assertTrue(module.should_show_reset_button())
+
+        # If the question is correct
+        # DO not show the reset button
+        module = CapaFactory.create(rerandomize=RANDOMIZATION.ALWAYS, max_attempts=0, done=True, correct=True)
+        self.assertFalse(module.should_show_reset_button())
+
+        # Don't show reset button even if randomization is turned on
+        module = CapaFactory.create(rerandomize=RANDOMIZATION.ALWAYS, show_reset_button=False, done=False)
+        self.assertFalse(module.should_show_reset_button())
+
+        # Show reset button even if randomization is turned on and the problem is done
+        module = CapaFactory.create(rerandomize=RANDOMIZATION.ALWAYS, show_reset_button=False, done=True)
+        self.assertTrue(module.should_show_reset_button())
+
 
     def test_should_show_save_button(self):
 
@@ -1115,7 +1122,7 @@ class CapaModuleTest(unittest.TestCase):
         self.assertFalse(module.should_show_save_button())
 
         # If user submitted a problem but hasn't reset, do NOT show the save button
-        module = CapaFactory.create(rerandomize="always", done=True)
+        module = CapaFactory.create(rerandomize=RANDOMIZATION.ALWAYS, done=True)
         self.assertFalse(module.should_show_save_button())
 
         module = CapaFactory.create(rerandomize="true", done=True)
@@ -1124,27 +1131,27 @@ class CapaModuleTest(unittest.TestCase):
         # If the user has unlimited attempts and we are not randomizing,
         # then do NOT show a save button
         # because they can keep using "Check"
-        module = CapaFactory.create(max_attempts=None, rerandomize="never", done=False)
+        module = CapaFactory.create(max_attempts=None, rerandomize=RANDOMIZATION.NEVER, done=False)
         self.assertFalse(module.should_show_save_button())
 
         module = CapaFactory.create(max_attempts=None, rerandomize="false", done=True)
         self.assertFalse(module.should_show_save_button())
 
-        module = CapaFactory.create(max_attempts=None, rerandomize="per_student", done=True)
+        module = CapaFactory.create(max_attempts=None, rerandomize=RANDOMIZATION.PER_STUDENT, done=True)
         self.assertFalse(module.should_show_save_button())
 
         # pre-studio default, DO show the save button
-        module = CapaFactory.create(rerandomize="always", done=False)
+        module = CapaFactory.create(rerandomize=RANDOMIZATION.ALWAYS, done=False)
         self.assertTrue(module.should_show_save_button())
 
         # If we're not randomizing and we have limited attempts,  then we can save
-        module = CapaFactory.create(rerandomize="never", max_attempts=2, done=True)
+        module = CapaFactory.create(rerandomize=RANDOMIZATION.NEVER, max_attempts=2, done=True)
         self.assertTrue(module.should_show_save_button())
 
         module = CapaFactory.create(rerandomize="false", max_attempts=2, done=True)
         self.assertTrue(module.should_show_save_button())
 
-        module = CapaFactory.create(rerandomize="per_student", max_attempts=2, done=True)
+        module = CapaFactory.create(rerandomize=RANDOMIZATION.PER_STUDENT, max_attempts=2, done=True)
         self.assertTrue(module.should_show_save_button())
 
         # If survey question for capa (max_attempts = 0),
@@ -1172,7 +1179,7 @@ class CapaModuleTest(unittest.TestCase):
         # then show it even if we would ordinarily
         # require a reset first
         module = CapaFactory.create(force_save_button="true",
-                                    rerandomize="always",
+                                    rerandomize=RANDOMIZATION.ALWAYS,
                                     done=True)
         self.assertTrue(module.should_show_save_button())
 
@@ -1309,9 +1316,12 @@ class CapaModuleTest(unittest.TestCase):
     def test_random_seed_no_change(self):
 
         # Run the test for each possible rerandomize value
-        for rerandomize in ['false', 'never',
-                            'per_student', 'always',
-                            'true', 'onreset']:
+        for rerandomize in ['false',
+                            'true',
+                            RANDOMIZATION.NEVER,
+                            RANDOMIZATION.PER_STUDENT,
+                            RANDOMIZATION.ALWAYS,
+                            RANDOMIZATION.ONRESET]:
             module = CapaFactory.create(rerandomize=rerandomize)
 
             # Get the seed
@@ -1321,7 +1331,7 @@ class CapaModuleTest(unittest.TestCase):
 
             # If we're not rerandomizing, the seed is always set
             # to the same value (1)
-            if rerandomize in ['never']:
+            if rerandomize == RANDOMIZATION.NEVER:
                 self.assertEqual(seed, 1,
                                  msg="Seed should always be 1 when rerandomize='%s'" % rerandomize)
 
@@ -1341,13 +1351,13 @@ class CapaModuleTest(unittest.TestCase):
     def test_random_seed_with_reset(self):
 
         def _reset_and_get_seed(module):
-            '''
+            """
             Reset the XModule and return the module's seed
-            '''
+            """
 
             # Simulate submitting an attempt
             # We need to do this, or reset_problem() will
-            # fail with a complaint that we haven't submitted
+            # fail because it won't re-randomize until the problem has been submitted
             # the problem yet.
             module.done = True
 
@@ -1373,9 +1383,14 @@ class CapaModuleTest(unittest.TestCase):
             return success
 
         # Run the test for each possible rerandomize value
-        for rerandomize in ['never', 'false', 'per_student',
-                            'always', 'true', 'onreset']:
-            module = CapaFactory.create(rerandomize=rerandomize)
+        for rerandomize in ['false',
+                            'true',
+                            RANDOMIZATION.NEVER,
+                            RANDOMIZATION.PER_STUDENT,
+                            RANDOMIZATION.ALWAYS,
+                            RANDOMIZATION.ONRESET]:
+
+            module = CapaFactory.create(rerandomize=rerandomize, done=True)
 
             # Get the seed
             # By this point, the module should have persisted the seed
@@ -1386,7 +1401,9 @@ class CapaModuleTest(unittest.TestCase):
             # is set to 'never' -- it should still be 1
             # The seed also stays the same if we're randomizing
             # 'per_student': the same student should see the same problem
-            if rerandomize in ['never', 'false', 'per_student']:
+            if rerandomize in [RANDOMIZATION.NEVER,
+                               'false',
+                               RANDOMIZATION.PER_STUDENT]:
                 self.assertEqual(seed, _reset_and_get_seed(module))
 
             # Otherwise, we expect the seed to change
@@ -1402,11 +1419,46 @@ class CapaModuleTest(unittest.TestCase):
                 msg = 'Could not get a new seed from reset after 5 tries'
                 self.assertTrue(success, msg)
 
+    def test_random_seed_with_reset_question_unsubmitted(self):
+
+        def _reset_and_get_seed(module):
+            '''
+            Reset the XModule and return the module's seed
+            '''
+
+            # Reset the problem
+            # By default, the problem is instantiated as unsubmitted
+            module.reset_problem({})
+
+            # Return the seed
+            return module.seed
+
+        # Run the test for each possible rerandomize value
+        for rerandomize in ['false',
+                            'true',
+                            RANDOMIZATION.NEVER,
+                            RANDOMIZATION.PER_STUDENT,
+                            RANDOMIZATION.ALWAYS,
+                            RANDOMIZATION.ONRESET]:
+
+            module = CapaFactory.create(rerandomize=rerandomize, done=False)
+
+            # Get the seed
+            # By this point, the module should have persisted the seed
+            seed = module.seed
+            self.assertTrue(seed is not None)
+
+            #the seed should never change because the student hasn't finished the problem
+            self.assertEqual(seed, _reset_and_get_seed(module))
+
     def test_random_seed_bins(self):
         # Assert that we are limiting the number of possible seeds.
 
         # Check the conditions that generate random seeds
-        for rerandomize in ['always', 'per_student', 'true', 'onreset']:
+        for rerandomize in [RANDOMIZATION.ALWAYS,
+                            RANDOMIZATION.PER_STUDENT,
+                            'true',
+                            RANDOMIZATION.ONRESET]:
             # Get a bunch of seeds, they should all be in 0-999.
             for i in range(200):
                 module = CapaFactory.create(rerandomize=rerandomize)
@@ -1622,7 +1674,7 @@ class TestProblemCheckTracking(unittest.TestCase):
                 </checkboxgroup>
               </choiceresponse>
             </problem>
-            """)
+           """)
         module = factory.create()
 
         answer_input_dict = {
@@ -1740,7 +1792,7 @@ class TestProblemCheckTracking(unittest.TestCase):
 
     def test_rerandomized_inputs(self):
         factory = CapaFactory
-        module = factory.create(rerandomize='always')
+        module = factory.create(rerandomize=RANDOMIZATION.ALWAYS)
 
         answer_input_dict = {
             factory.input_key(2): '3.14'


### PR DESCRIPTION
@jbau @jrbl  to review please

Decouples reset from randomization while still preserving backward compatibility. Users will be able to effectively clear their input for answere questions that they have not submitted and instructors are able to set course-wide and problem-specific settings.

Implementation is in common/lib/xmodule/xmodule/capa_base.py  
Refactored out common constants in common/lib/xmodule/xmodule/capa_base_constants.py
Unit tests in common/lib/xmodule/xmodule/tests/test_capa_module.py
UI acceptance tests in common/test/acceptance/tests/test_problem_reset.py 
