### PR TITLE
Upgrade ORA2

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -28,7 +28,7 @@
 -e git+https://github.com/edx/bok-choy.git@2e6eab960a97fe41778292fe8e1b2f0b69a1be2d#egg=bok_choy
 -e git+https://github.com/edx-solutions/django-splash.git@7579d052afcf474ece1239153cffe1c89935bc4f#egg=django-splash
 -e git+https://github.com/edx/acid-block.git@459aff7b63db8f2c5decd1755706c1a64fb4ebb1#egg=acid-xblock
--e git+https://github.com/Stanford-Online/edx-ora2.git@a778bf50df07a517d1905eee2d66eb19a29750b0#egg=edx-ora2
+-e git+https://github.com/Stanford-Online/edx-ora2.git@10c95f7de756415d62fa1b4f3299a070c5c45c9f#egg=edx-ora2
 -e git+https://github.com/edx/opaque-keys.git@a7c506befdf9b97bbbb6961e0b0c7fa4807003eb#egg=opaque-keys
 -e git+https://github.com/edx/ease.git@97de68448e5495385ba043d3091f570a699d5b5f#egg=ease
 -e git+https://github.com/edx/i18n-tools.git@0d7847f9dfa2281640527b4dc51f5854f950f9b7#egg=i18n-tools


### PR DESCRIPTION
https://github.com/Stanford-Online/edx-ora2/commit/10c95f7de756415d62fa1b4f3299a070c5c45c9f

@jrbl @caesar2164 

Note: The commit on the ORA2 repo will need to be tagged upon release.
