### PR TITLE
Install analytics repo from a SHA _not_ a tag

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -24,7 +24,7 @@
 -e git+https://github.com/edx/js-test-tool.git@v0.1.5#egg=js_test_tool
 -e git+https://github.com/edx/django-waffle.git@823a102e48#egg=django-waffle
 -e git+https://github.com/edx/event-tracking.git@0.1.0#egg=event-tracking
--e git+https://github.com/edx/edx-analytics-data-api-client.git@0.1.0#egg=edx-analytics-data-api-client
+-e git+https://github.com/edx/edx-analytics-data-api-client.git@c2264bdd604eb0a603afa5d88c884edfdeb8089a#egg=edx-analytics-data-api-client
 -e git+https://github.com/edx/bok-choy.git@2e6eab960a97fe41778292fe8e1b2f0b69a1be2d#egg=bok_choy
 -e git+https://github.com/edx-solutions/django-splash.git@7579d052afcf474ece1239153cffe1c89935bc4f#egg=django-splash
 -e git+https://github.com/edx/acid-block.git@459aff7b63db8f2c5decd1755706c1a64fb4ebb1#egg=acid-xblock


### PR DESCRIPTION
The v0.1 tag was mistakenly removed from upstream. While attempting to
restore it, it was restored to point to an earlier, incorrect
SHA/object.

Git does not support "renaming" of tags (changes to existing tags are
ignored), so environments which still had a local, cached copy of the
original tag were unaffected. Fresh installs were broken.

This change pins the version to the original source SHA, instead of a
tag.
