### PR TITLE
Add price field to studio and logic to show/hide price

### DIFF
--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -175,6 +175,12 @@ class CourseFields(object):
                  default=DEFAULT_START_DATE,
                  scope=Scope.settings)
     end = Date(help="Date that this class ends", scope=Scope.settings)
+    display_price = Integer(
+        display_name=_("Course Display Price"),
+        help=_("The cost displayed to students for enrolling in the course. If a paid course registration price is set by platform staff in the database, that price will be displayed instead of this one."),
+        default=0,
+        scope=Scope.settings,
+    )
     advertised_start = String(
         display_name=_("Course Advertised Start Date"),
         help=_("Enter the date you want to advertise as the course start date, if this date is different from the set start date. To advertise the set start date, enter null."),

--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -192,6 +192,24 @@ class ViewsTestCase(TestCase):
         mock_course.id = self.course_key
         self.assertTrue(views.registered_for_course(mock_course, self.user))
 
+    @override_settings(PAID_COURSE_REGISTRATION_CURRENCY=["USD", "$"])
+    def test_get_course_display_price(self):
+        """
+        Check that get_course_display_price() returns the correct price given its inputs.
+        """
+        registration_price = 99
+        self.course.display_price = 10
+        # Since registration_price is set, it overrides the cosmetic display_price and should be returned
+        self.assertEqual(views.get_course_display_price(self.course, registration_price), "$99")
+        
+        # Since registration_price is not set, display_price should be returned
+        registration_price = 0
+        self.assertEqual(views.get_course_display_price(self.course, registration_price), "$10")
+        
+        # Since both prices are not set, there is no price, thus "Free"
+        self.course.display_price = 0
+        self.assertEqual(views.get_course_display_price(self.course, registration_price), "Free")
+
     def test_jump_to_invalid(self):
         # TODO add a test for invalid location
         # TODO add a test for no data *

--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -648,6 +648,22 @@ def registered_for_course(course, user):
         return False
 
 
+def get_course_display_price(course, registration_price):
+    """
+    Return Course Price as a string preceded by correct currency, or 'Free'
+    """
+    currency_symbol = settings.PAID_COURSE_REGISTRATION_CURRENCY[1]
+    
+    price = course.display_price
+    if registration_price > 0:
+        price = registration_price
+    
+    if price:
+        return "{}{}".format(currency_symbol, price)
+    else:
+        return  _('Free')
+
+
 @ensure_csrf_cookie
 @cache_if_anonymous
 def course_about(request, course_id):
@@ -694,6 +710,8 @@ def course_about(request, course_id):
         reg_then_add_to_cart_link = "{reg_url}?course_id={course_id}&enrollment_action=add_to_cart".format(
             reg_url=reverse('register_user'), course_id=course.id.to_deprecated_string())
 
+    course_display_price = get_course_display_price(course, registration_price)
+
     # only allow course sneak peek if
     # 1) within enrollment period
     # 2) course specifies it's okay
@@ -724,6 +742,7 @@ def course_about(request, course_id):
         'sneakpeek_allowed': sneakpeek_allowed,
         'course_target': course_target,
         'registration_price': registration_price,
+        'course_display_price': course_display_price,
         'in_cart': in_cart,
         'reg_then_add_to_cart_link': reg_then_add_to_cart_link,
         'show_courseware_link': show_courseware_link,

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -357,7 +357,13 @@
             % endif
       
             ##<li><div class="icon length"></div><p>${_('Course Length')}</p><span class="course-length">${_('{number} weeks').format(number=15)}</span></li>
-      
+            
+            <li>
+                <i class="icon icon-money"></i>
+                <p>${_("Price")}</p>
+                <span>${course_display_price}</span>
+            </li>
+            
             % if get_course_about_section(course, "prerequisites"):
               <li class="prerequisites"><div class="icon prereq"></div><p>${_("Prerequisites")}</p><span class="start-date">${get_course_about_section(course, "prerequisites")}</span></li>
             % endif


### PR DESCRIPTION
@stvstnfrd & @jbau 

Screenshots to give a better idea of functionality:

Set "Course Price" in studio (Advanced Setting):
![screen shot 2014-10-16 at 3 54 36 pm](https://cloud.githubusercontent.com/assets/3364609/4671919/7fd435c2-5587-11e4-8d6d-2b7806d61e50.png)

"Course Price" is displayed on About Page:
![screen shot 2014-10-14 at 11 22 04 am](https://cloud.githubusercontent.com/assets/3364609/4634345/5d354e7a-53cf-11e4-90e6-032c0b78427a.png)

By default the field is set to 0:
![screen shot 2014-10-16 at 3 54 14 pm](https://cloud.githubusercontent.com/assets/3364609/4671928/906a1370-5587-11e4-9a3d-8941d1301d9a.png)

Which displays like this:
![screen shot 2014-10-16 at 4 07 11 pm](https://cloud.githubusercontent.com/assets/3364609/4672076/3b5bf266-5589-11e4-89a6-b43cedd8dd9a.png)
