### PR TITLE
Add Course About Page sidebar text area

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_course_settings.py
+++ b/cms/djangoapps/contentstore/tests/test_course_settings.py
@@ -84,6 +84,11 @@ class CourseDetailsTestCase(CourseTestCase):
             CourseDetails.update_from_json(self.course.id, jsondetails.__dict__, self.user).short_description,
             jsondetails.short_description, "After set short_description"
         )
+        jsondetails.about_sidebar_html = "About Sidebar HTML"
+        self.assertEqual(
+            CourseDetails.update_from_json(self.course.id, jsondetails.__dict__, self.user).about_sidebar_html,
+            jsondetails.about_sidebar_html, "After set about_sidebar_html"
+        )
         jsondetails.overview = "Overview"
         self.assertEqual(
             CourseDetails.update_from_json(self.course.id, jsondetails.__dict__, self.user).overview,
@@ -129,6 +134,7 @@ class CourseDetailsTestCase(CourseTestCase):
             self.assertContains(response, "Introducing Your Course")
             self.assertContains(response, "Course Image")
             self.assertContains(response, "Course Short Description")
+            self.assertNotContains(response, "Course About Sidebar HTML")
             self.assertNotContains(response, "Course Overview")
             self.assertNotContains(response, "Course Introduction Video")
             self.assertNotContains(response, "Requirements")
@@ -159,6 +165,7 @@ class CourseDetailsTestCase(CourseTestCase):
             self.assertContains(response, "Introducing Your Course")
             self.assertContains(response, "Course Image")
             self.assertContains(response, "Course Short Description")
+            self.assertContains(response, "Course About Sidebar HTML")
             self.assertContains(response, "Course Overview")
             self.assertContains(response, "Course Introduction Video")
             self.assertContains(response, "Requirements")
@@ -205,6 +212,7 @@ class CourseDetailsViewTest(CourseTestCase):
 
         self.alter_field(url, details, 'enrollment_end', datetime.datetime(2012, 11, 15, 1, 30, tzinfo=utc))
         self.alter_field(url, details, 'short_description', "Short Description")
+        self.alter_field(url, details, 'about_sidebar_html', "About Sidebar HTML")
         self.alter_field(url, details, 'overview', "Overview")
         self.alter_field(url, details, 'intro_video', "intro_video")
         self.alter_field(url, details, 'effort', "effort")
@@ -219,6 +227,7 @@ class CourseDetailsViewTest(CourseTestCase):
         self.compare_date_fields(details, encoded, context, 'enrollment_start')
         self.compare_date_fields(details, encoded, context, 'enrollment_end')
         self.assertEqual(details['short_description'], encoded['short_description'], context + " short_description not ==")
+        self.assertEqual(details['about_sidebar_html'], encoded['about_sidebar_html'], context + " about_sidebar_html not ==")
         self.assertEqual(details['overview'], encoded['overview'], context + " overviews not ==")
         self.assertEqual(details['intro_video'], encoded.get('intro_video', None), context + " intro_video not ==")
         self.assertEqual(details['effort'], encoded['effort'], context + " efforts not ==")

--- a/cms/djangoapps/models/settings/course_details.py
+++ b/cms/djangoapps/models/settings/course_details.py
@@ -25,6 +25,7 @@ class CourseDetails(object):
         self.syllabus = None  # a pdf file asset
         self.short_description = ""
         self.overview = ""  # html to render as the overview
+        self.about_sidebar_html = "" # html to render as the about_sidebar_html
         self.pre_enrollment_email = render_to_string('emails/default_pre_enrollment_message.txt', {})
         self.post_enrollment_email = render_to_string('emails/default_post_enrollment_message.txt', {})
         self.pre_enrollment_email_subject = "Thanks for Enrolling in {}".format(self.course_id)
@@ -68,6 +69,13 @@ class CourseDetails(object):
             course_details.overview = modulestore().get_item(temploc).data
         except ItemNotFoundError:
             pass
+
+        temploc = course_key.make_usage_key('about', 'about_sidebar_html')
+        try:
+            course_details.about_sidebar_html = modulestore().get_item(temploc).data
+        except ItemNotFoundError:
+            pass
+
         temploc = course_key.make_usage_key('about', 'pre_enrollment_email_subject')
         try:
             course_details.pre_enrollment_email_subject = modulestore().get_item(temploc).data
@@ -193,7 +201,7 @@ class CourseDetails(object):
 
         # NOTE: below auto writes to the db w/o verifying that any of the fields actually changed
         # to make faster, could compare against db or could have client send over a list of which fields changed.
-        for about_type in ['syllabus', 'overview', 'effort', 'short_description', 
+        for about_type in ['syllabus', 'overview', 'about_sidebar_html', 'effort', 'short_description', 
                            'pre_enrollment_email', 'post_enrollment_email', 'pre_enrollment_email_subject', 
                            'post_enrollment_email_subject']:
             cls.update_about_item(course_key, about_type, jsondict[about_type], descriptor, user)

--- a/cms/static/js/views/settings/main.js
+++ b/cms/static/js/views/settings/main.js
@@ -12,6 +12,7 @@ var DetailsView = ValidatingView.extend({
         "change textarea" : "updateModel",
         'click .remove-course-introduction-video' : "removeVideo",
         'focus #course-overview' : "codeMirrorize",
+        'focus #course-about-sidebar-html' : "codeMirrorize",
         'click #enable-enrollment-email' : "toggleEnrollmentEmails",
         'focus #pre-enrollment-email' : "codeMirrorize",
         'focus #post-enrollment-email' : "codeMirrorize",
@@ -76,6 +77,9 @@ var DetailsView = ValidatingView.extend({
 
         this.$el.find('#' + this.fieldToSelectorMap['overview']).val(this.model.get('overview'));
         this.codeMirrorize(null, $('#course-overview')[0]);
+        
+        this.$el.find('#' + this.fieldToSelectorMap['about_sidebar_html']).val(this.model.get('about_sidebar_html'));
+        this.codeMirrorize(null, $('#course-about-sidebar-html')[0]);
 
         this.pre_enrollment_email_subject_elem.val(this.model.get('pre_enrollment_email_subject'));
         this.post_enrollment_email_subject_elem.val(this.model.get('post_enrollment_email_subject'));
@@ -117,6 +121,7 @@ var DetailsView = ValidatingView.extend({
         'enrollment_start' : 'enrollment-start',
         'enrollment_end' : 'enrollment-end',
         'overview' : 'course-overview',
+        'about_sidebar_html' : 'course-about-sidebar-html',
         'pre_enrollment_email' : 'pre-enrollment-email',
         'post_enrollment_email' : 'post-enrollment-email',
         'short_description' : 'course-short-description',

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -237,6 +237,20 @@ require(["domReady!", "jquery", "js/models/settings/course_details", "js/views/s
                     %>${text}</%def>
                   <span class="tip tip-stacked">${overview_text()}</span>
                 </li>
+                
+                <li class="field text" id="field-course-about-sidebar-html">
+                    <label for="course-about-sidebar-html">${_("Course About Sidebar HTML")}</label>
+                    <textarea class="tinymce text-editor" id="course-about-sidebar-html"></textarea>
+                    <%def name='about_sidebar_html()'><%
+                        anchor = '<a class="link-courseURL" rel="external" href="{href_url}">{href_text}</a>'
+                        anchor = anchor.format(
+                            href_url=lms_link_for_about_page,
+                            href_text=_("your course summary page"),
+                        )
+                        html_sidebar = _("Custom sidebar content for {link} (formatted in HTML)").format(link=anchor)
+                    %>${html_sidebar}</%def>
+                    <span class="tip tip-stacked">${about_sidebar_html()}</span>
+                </li>
                 % endif
 
                 <li class="field image" id="field-course-image">

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -159,6 +159,7 @@ def get_course_about_section(course, section_key):
 
     Valid keys:
     - overview
+    - about_sidebar_html
     - title
     - university
     - number
@@ -188,7 +189,7 @@ def get_course_about_section(course, section_key):
     if section_key in ['short_description', 'description', 'key_dates', 'video',
                        'course_staff_short', 'course_staff_extended',
                        'requirements', 'syllabus', 'textbook', 'faq', 'more_info',
-                       'number', 'instructors', 'overview',
+                       'number', 'instructors', 'overview', 'about_sidebar_html',
                        'effort', 'end_date', 'prerequisites', 'ocw_links', 
                        'pre_enrollment_email', 'post_enrollment_email', 
                        'pre_enrollment_email_subject', 'post_enrollment_email_subject']:

--- a/lms/djangoapps/courseware/tests/test_about.py
+++ b/lms/djangoapps/courseware/tests/test_about.py
@@ -257,3 +257,29 @@ class AboutWithClosedEnrollment(ModuleStoreTestCase):
 
         # Check that registration button is not present
         self.assertNotIn(REG_STR, resp.content)
+
+
+@override_settings(MODULESTORE=TEST_DATA_MIXED_MODULESTORE)
+class AboutSidebarHTMLTestCase(ModuleStoreTestCase):
+    """
+    This test case will check the About page for the content in the HTML sidebar.
+    """
+    def setUp(self):
+        super(AboutSidebarHTMLTestCase, self).setUp()
+        self.course = CourseFactory.create()
+
+    def test_html_sidebar_empty(self):
+        url = reverse('about_course', args=[self.course.id.to_deprecated_string()])
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotIn("About Sidebar HTML Heading", resp.content)
+
+    def test_html_sidebar_has_content(self):
+        ItemFactory.create(
+            category="about", parent_location=self.course.location,
+            data="About Sidebar HTML Heading", display_name="about_sidebar_html"
+        )
+        url = reverse('about_course', args=[self.course.id.to_deprecated_string()])
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("About Sidebar HTML Heading", resp.content)

--- a/lms/static/sass/multicourse/_course_about.scss
+++ b/lms/static/sass/multicourse/_course_about.scss
@@ -399,7 +399,7 @@
 
       &.course-summary {
         padding: 16px 20px 30px;
-        margin-bottom: 220px;
+        margin-bottom: 50px;
         border-top: none;
       }
 

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -386,6 +386,12 @@
             </section>
           </section>
         %endif
+        
+        % if get_course_about_section(course, "about_sidebar_html"):
+            <section class="about-sidebar-html">
+                ${get_course_about_section(course, "about_sidebar_html")}
+            </section>
+        %endif
     </section>
     % endif
   </section>


### PR DESCRIPTION
- Add text area in Studio 'Schedule & Details' page
- Store text area content in mongo
- If text area in Studio has content, display sidebar section

@jrbl & @stvstnfrd - making it possible to add arbitrary HTML to course_about sidebar
