### PR TITLE
Bulk captions download subs bug fix

### DIFF
--- a/cms/djangoapps/contentstore/views/utilities/captions.py
+++ b/cms/djangoapps/contentstore/views/utilities/captions.py
@@ -23,6 +23,7 @@ from xmodule.video_module.transcripts_utils import (
                                     GetTranscriptsFromYouTubeException,
                                     TranscriptsRequestValidationException,
                                     download_youtube_subs)
+from xmodule.video_module import manage_video_subtitles_save
 
 from ..transcripts_ajax import get_transcripts_presence
 from ..course import _get_course_module
@@ -87,6 +88,10 @@ def json_update_videos(request, locations):
             #update transcripts
             item = modulestore().get_item(key)
             download_youtube_subs(item.youtube_id_1_0, item, settings)
+
+            # Once transcripts downloaded, show subs are present from youtube
+            item.sub = item.youtube_id_1_0
+            manage_video_subtitles_save(item, request.user)
 
             #get new status
             videos = {'youtube': item.youtube_id_1_0}


### PR DESCRIPTION
Fixes a bug in handling bug captions where the download captions button didn't
appear on a video's view even with the option to allow caption downloads set to
true and captions properly set through the bulk captions utiltity.
The button would not appear until the studio user saved the video settings
again.

The cause of the bug was within the operation of the bulk captions
utility downloading the subtitles for a video from youtube. It correctly
downloaded and saved the subs to the database, but never set the sub field
of the video descriptor to be the id of the new subtitles saved in the
db. To fix this, a pre-existing function which handles all needed updates
is used to ensure that the sub field is properly updated along with the subs
saved in the db.
