### PR TITLE
Reformat student submissions reports

### DIFF
--- a/lms/djangoapps/instructor_analytics/tests/test_basic.py
+++ b/lms/djangoapps/instructor_analytics/tests/test_basic.py
@@ -287,50 +287,14 @@ class TestStudentSubmissionsAnalyticsBasic(ModuleStoreTestCase):
         self.course = CourseFactory.create()
         self.create_student()
 
-        header, datarows = student_submissions(self.course, all_students=True)
-        self.assertEqual(header, ["Section","Subsection","Unit","Problem",self.student.username])
+        datarows = list(student_submissions(self.course))
         self.assertEqual(datarows, [])
 
     def test_full_course_no_students(self):
         self.load_course('edX/simple/2012_Fall')
 
-        header, datarows = student_submissions(self.course, all_students=True)
-        self.assertEqual(header, [])
+        datarows = list(student_submissions(self.course))
         self.assertEqual(datarows, [])
-
-    def test_unicode_submissions(self):
-        self.load_course('edX/graded/2012_Fall')
-        self.problem_location = Location("edX", "graded", "2012_Fall", "problem", "H1P2")
-
-        self.create_student()
-        StudentModuleFactory.create(
-            course_id=self.course.id,
-            module_state_key=self.problem_location,
-            student=self.student,
-            grade=0,
-            state=u'{"student_answers":{"fake-problem":"caf\xe9"}}'
-        )
-
-        header, datarows = student_submissions(self.course)
-        #One data row means the answer was successfully encoded and appended
-        self.assertEqual(len(datarows), 1)
-
-    def test_unicode_course(self):
-        self.load_course('edX/unicode_graded/2012_Fall')
-        self.problem_location = Location("edX", "unicode_graded", "2012_Fall", "problem", "H1P1")
-
-        self.create_student()
-        StudentModuleFactory.create(
-            course_id=self.course.id,
-            module_state_key=self.problem_location,
-            student=self.student,
-            grade=0,
-            state=u'{"student_answers":{"fake-problem":"No idea"}}'
-        )
-
-        header, datarows = student_submissions(self.course)
-        #One data row means the answer was successfully encoded and appended
-        self.assertEqual(len(datarows), 1)
 
     def test_invalid_module_state(self):
         self.load_course('edX/graded/2012_Fall')
@@ -345,6 +309,6 @@ class TestStudentSubmissionsAnalyticsBasic(ModuleStoreTestCase):
             state=u'{"student_answers":{"fake-problem":"No idea"}}}'
         )
 
-        header, datarows = student_submissions(self.course)
+        datarows = list(student_submissions(self.course))
         #Invalid module state submission will be skipped, so datarows should be empty
         self.assertEqual(len(datarows), 0)

--- a/lms/djangoapps/instructor_task/tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tasks_helper.py
@@ -25,7 +25,7 @@ from courseware.models import StudentModule
 from courseware.model_data import FieldDataCache
 from courseware.module_render import get_module_for_descriptor_internal
 from instructor.utils import collect_ora2_data
-from instructor_analytics.basic import student_submissions, enrolled_students_features
+from instructor_analytics.basic import student_submission_rows, enrolled_students_features
 from instructor_analytics.csvs import format_dictlist
 from instructor_task.models import ReportStore, InstructorTask, PROGRESS
 from student.models import CourseEnrollment
@@ -614,8 +614,7 @@ def push_student_submissions_to_s3(_xmodule_instance_args, _entry_id, course_id,
         TASK_LOG.error(e.message)
         return "failed"
 
-    header, datarows = student_submissions(course)
-    rows = [header] + datarows
+    rows = student_submission_rows(course)
 
     # Generate parts of the file name
     timestamp_str = start_time.strftime("%Y-%m-%d-%H%M")


### PR DESCRIPTION
@jbau @jrbl @dcadams 

To use, go to instructor dashboard -> Data Download -> Reports section -> Get Student Submissions Report. This does not include students with no submissions.

Also includes management command that can be called like follows:
./manage.py lms dump_student_submissions edX/DemoX/Demo_Course -o output.csv


Also fixes some broken unicode encoding logic from merging with upstream, causing unicode characters to be encoded twice.

You can reproduce this error on prod by answering any problem in a sandbox course with a unicode character, and then going into the instructor dashboard and try to generate a student submissions report, it should throw the UnicodeDecodeError.

If you checkout this branch and do the same thing, it should generate the submission fine.