### PR TITLE
Fix unicode encoding issue and add better unit test

### DIFF
--- a/lms/djangoapps/instructor/management/commands/dump_student_submissions.py
+++ b/lms/djangoapps/instructor/management/commands/dump_student_submissions.py
@@ -48,10 +48,14 @@ class Command(BaseCommand):
         header, datarows = student_submissions(course, options['all_students'])
         rows = [header] + datarows
 
+        def _utf8_encoded_rows(rows):
+            for row in rows:
+                yield [unicode(item).encode('utf-8') for item in row]
+
         if not options['filename']:
             csvwriter = csv.writer(self.stdout, dialect='excel', quotechar='"', quoting=csv.QUOTE_ALL)
-            csvwriter.writerows(rows)
+            csvwriter.writerows(_utf8_encoded_rows(rows))
         else:
             with open(options['filename'], 'wb') as csvfile:
                 csvwriter = csv.writer(csvfile, dialect='excel', quotechar='"', quoting=csv.QUOTE_ALL)
-                csvwriter.writerows(rows)
+                csvwriter.writerows(_utf8_encoded_rows(rows))

--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -397,10 +397,10 @@ def student_submissions(course, all_students=False):
             for unit in subsection.get_children():
                 unit_name = unit.display_name_with_default
 
-                row = [section_name.encode('utf-8'), subsection_name.encode('utf-8'), unit_name.encode('utf-8'), '']
+                row = [section_name, subsection_name, unit_name, '']
                 for component in unit.get_children():
                     if component.category == 'problem':
-                        row[-1] = component.display_name_with_default.encode('utf-8')
+                        row[-1] = component.display_name_with_default
                         modules = StudentModule.objects.filter(course_id=course.id, grade__isnull=False, module_state_key=component.location)
                         if modules:
                             answers = [''] * len(students)
@@ -413,7 +413,7 @@ def student_submissions(course, all_students=False):
                                               "StudentModule id={}, course={}".format(module.id, course.id))
                                     continue
                                 pretty_answers = u', '.join(u"{problem}={answer}".format(problem=problem, answer=answer) for (problem, answer) in raw_answers.items())
-                                answers[student_cols[module.student.username]] = pretty_answers.encode('utf-8')
+                                answers[student_cols[module.student.username]] = pretty_answers
                             if any(answers):
                                 datarows.append(row + answers)
 

--- a/lms/djangoapps/instructor_analytics/tests/test_basic.py
+++ b/lms/djangoapps/instructor_analytics/tests/test_basic.py
@@ -298,40 +298,6 @@ class TestStudentSubmissionsAnalyticsBasic(ModuleStoreTestCase):
         self.assertEqual(header, [])
         self.assertEqual(datarows, [])
 
-    def test_unicode_submissions(self):
-        self.load_course('edX/graded/2012_Fall')
-        self.problem_location = Location("edX", "graded", "2012_Fall", "problem", "H1P2")
-
-        self.create_student()
-        StudentModuleFactory.create(
-            course_id=self.course.id,
-            module_state_key=self.problem_location,
-            student=self.student,
-            grade=0,
-            state=u'{"student_answers":{"fake-problem":"caf\xe9"}}'
-        )
-
-        header, datarows = student_submissions(self.course)
-        #One data row means the answer was successfully encoded and appended
-        self.assertEqual(len(datarows), 1)
-
-    def test_unicode_course(self):
-        self.load_course('edX/unicode_graded/2012_Fall')
-        self.problem_location = Location("edX", "unicode_graded", "2012_Fall", "problem", "H1P1")
-
-        self.create_student()
-        StudentModuleFactory.create(
-            course_id=self.course.id,
-            module_state_key=self.problem_location,
-            student=self.student,
-            grade=0,
-            state=u'{"student_answers":{"fake-problem":"No idea"}}'
-        )
-
-        header, datarows = student_submissions(self.course)
-        #One data row means the answer was successfully encoded and appended
-        self.assertEqual(len(datarows), 1)
-
     def test_invalid_module_state(self):
         self.load_course('edX/graded/2012_Fall')
         self.problem_location = Location("edX", "graded", "2012_Fall", "problem", "H1P2")

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -15,11 +15,19 @@ from mock import Mock, patch
 from django.test.testcases import TestCase
 from pytz import UTC
 
+from courseware.courses import get_course
+from courseware.tests.factories import StudentModuleFactory
+from courseware.tests.modulestore_config import TEST_DATA_MIXED_MODULESTORE
+from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.locations import Location
+from student.tests.factories import CourseEnrollmentFactory, UserFactory
 from xmodule.modulestore.tests.factories import CourseFactory
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 
 from instructor_task.tasks_helper import (
     upload_grades_csv,
     upload_students_csv,
+    push_student_submissions_to_s3,
     push_ora2_responses_to_s3,
     UPDATE_STATUS_FAILED,
     UPDATE_STATUS_SUCCEEDED,
@@ -31,6 +39,8 @@ TEST_COURSE_NUMBER = '1.23x'
 from instructor_task.models import ReportStore
 from instructor_task.tests.test_base import InstructorTaskCourseTestCase, TestReportMixin
 from django.conf import settings
+from django.test.utils import override_settings
+
 
 @ddt.ddt
 class TestInstructorGradeReport(TestReportMixin, InstructorTaskCourseTestCase):
@@ -117,6 +127,31 @@ class TestStudentReport(TestReportMixin, InstructorTaskCourseTestCase):
         #This assertion simply confirms that the generation completed with no errors
         num_students = len(students)
         self.assertDictContainsSubset({'attempted': num_students, 'succeeded': num_students, 'failed': 0}, result)
+
+
+@override_settings(MODULESTORE=TEST_DATA_MIXED_MODULESTORE)
+class TestSubmissionsReport(TestReportMixin, ModuleStoreTestCase):
+    """
+    Tests that CSV student submissions report generation works.
+    """
+    def test_unicode(self):
+        course_key = CourseKey.from_string('edX/unicode_graded/2012_Fall')
+        self.course = get_course(course_key)
+        self.problem_location = Location("edX", "unicode_graded", "2012_Fall", "problem", "H1P1")
+
+        self.student = UserFactory(username=u'student\xec')
+        CourseEnrollmentFactory.create(user=self.student, course_id=self.course.id)
+
+        StudentModuleFactory.create(
+            course_id=self.course.id,
+            module_state_key=self.problem_location,
+            student=self.student,
+            grade=0,
+            state=u'{"student_answers":{"fake-problem":"caf\xe9"}}'
+        )
+
+        result = push_student_submissions_to_s3(None, None, self.course.id, None, 'generated')
+        self.assertEqual(result, "succeeded")
 
 
 class TestInstructorOra2Report(TestReportMixin, InstructorTaskCourseTestCase):


### PR DESCRIPTION
Some unicode encoding logic from merging with upstream was the issue, causing unicode characters to be encoded twice.

You can reproduce this error on prod by answering any problem in a sandbox course with a unicode character, and then going into the instructor dashboard and try to generate a student submissions report, it should throw the UnicodeDecodeError.

If you checkout this branch and do the same thing, it should generate the submission fine.

@stvstnfrd 