### PR TITLE
Make report problem modal work with direct access

### DIFF
--- a/lms/templates/report_modal.html
+++ b/lms/templates/report_modal.html
@@ -2,6 +2,7 @@
 <%namespace name='static' file='static_content.html'/>
 <%! from django.conf import settings %>
 <%! from microsite_configuration import microsite %>
+<%! from student.models import UserProfile %>
 <%! platform_name = microsite.get_value("platform_name", settings.PLATFORM_NAME) %>
 
 <div class="report-tab">
@@ -24,7 +25,7 @@
       <p>${_("If you've found a problem on this page (e.g. an error), please let us know! For other questions, please check out the 'Help' tab.")}</p>
       <hr>
       <div id="report-error" class="modal-form-error" tabindex="-1"></div>
-% if not user.is_authenticated():
+% if not UserProfile.has_registered(user):
       <label data-field="name" for="report-form-name">${_('Name')}*</label>
       <input name="name" type="text" id="report-form-name" aria-required="true">
       <label data-field="email" for="report-form-email">${_('E-mail')}*</label>


### PR DESCRIPTION
Fixes a bug where non signed-in users could not send problem reports
for direct access allowed courses.

@stvstnfrd @jbau 