### PR TITLE
Add some padding so tabs don't overlap as much

### DIFF
--- a/lms/static/sass/base/_base.scss
+++ b/lms/static/sass/base/_base.scss
@@ -111,7 +111,8 @@ a:focus {
   width: flex-grid(12);
   margin: 0 auto;
   background: $content-wrapper-bg;
-  padding-bottom: ($baseline*2);
+  box-sizing: border-box;
+  padding: 0 $baseline ($baseline*2) $baseline;
 }
 
 .container {


### PR DESCRIPTION
@jbau & @stvstnfrd - quick fix.

Before:
![before](https://cloud.githubusercontent.com/assets/3364609/5685318/1187256c-97ee-11e4-8d40-4a100a4a3078.png)


After:
![after](https://cloud.githubusercontent.com/assets/3364609/5685321/167eac48-97ee-11e4-87f0-b3bb916ed9b7.png)
