### PR TITLE
Enable keyword substitution in emails on enrollment

### DIFF
--- a/cms/startup.py
+++ b/cms/startup.py
@@ -9,6 +9,8 @@ settings.INSTALLED_APPS  # pylint: disable=W0104
 
 from django_startup import autostartup
 from monkey_patch import django_utils_translation
+from util import keyword_substitution
+from lms.startup import get_keyword_function_map
 
 
 def run():
@@ -21,6 +23,11 @@ def run():
 
     add_mimetypes()
 
+    # Monkey patch the keyword function map
+    if keyword_substitution.keyword_function_map_is_empty():
+        keyword_substitution.add_keyword_function_map(get_keyword_function_map())
+        # Once keyword function map is set, make update function do nothing
+        keyword_substitution.add_keyword_function_map = lambda x: None
 
 def add_mimetypes():
     """

--- a/cms/static/js/views/settings/main.js
+++ b/cms/static/js/views/settings/main.js
@@ -1,6 +1,6 @@
 define(["js/views/validation", "codemirror", "underscore", "jquery", "jquery.ui", "js/utils/date_utils", "js/models/uploads",
-    "js/views/uploads", "js/utils/change_on_enter", "jquery.timepicker", "date"],
-    function(ValidatingView, CodeMirror, _, $, ui, DateUtils, FileUploadModel, FileUploadDialog, TriggerChangeEventOnEnter) {
+    "js/views/uploads", "js/utils/change_on_enter", "js/views/utils/view_utils", "jquery.timepicker", "date"],
+    function(ValidatingView, CodeMirror, _, $, ui, DateUtils, FileUploadModel, FileUploadDialog, TriggerChangeEventOnEnter, ViewUtils) {
 
 var DetailsView = ValidatingView.extend({
     // Model class is CMS.Models.Settings.CourseDetails
@@ -359,6 +359,7 @@ var DetailsView = ValidatingView.extend({
         var email_type = event.target.id;
         var subject = "";
         var message = "";
+        var validation;
         if (email_type === "test_email_pre") {
             subject = this.pre_enrollment_email_subject_elem.val();
             message = this.pre_enrollment_email_elem.val();
@@ -367,12 +368,18 @@ var DetailsView = ValidatingView.extend({
             message = this.post_enrollment_email_elem.val();
         }
 
-        $.post("/settings/send_test_enrollment_email",
+        validation = ViewUtils.keywordValidator.validateString(message);
+        if (!validation.isValid) {
+            message = gettext('There are invalid keywords in your email. Please check the following keywords and try again:');
+            message += "\n" + validation.keywordsInvalid.join('\n');
+            window.alert(message);
+            return;
+        }
+
+        $.post($(event.target).data('endpoint'),
                {
                  subject: subject,
-                 message:message,org:this.model.get('org'),
-                 number: this.model.get('course_id'),
-                 run: this.model.get('run'),
+                 message:message
                },
                function (data) {
                    alert(gettext("Test email sent! Please check your inbox. Don't forget to save!"));

--- a/cms/static/js/views/utils/view_utils.js
+++ b/cms/static/js/views/utils/view_utils.js
@@ -173,6 +173,31 @@ define(["jquery", "underscore", "gettext", "js/views/feedback_notification", "js
             return false;
         };
 
+        var keywordValidator = (function () {
+            var regexp = /%%[^%\s]+%%/g;
+            var keywordsSupported = ['%%USER_ID%%', '%%USER_FULLNAME%%', '%%COURSE_DISPLAY_NAME%%', '%%COURSE_END_DATE%%'];
+            function validate(string) {
+                var keywordsFound = string.match(regexp) || [];
+                var keywordsInvalid = $.map(keywordsFound, function (keyword) {
+                    if ($.inArray(keyword, keywordsSupported) === -1) {
+                        return keyword;
+                    } else {
+                        // return `null` or `undefined` to remove an element
+                        return undefined;
+                    }
+                });
+
+                return {
+                    'isValid': keywordsInvalid.length === 0,
+                    'keywordsInvalid': keywordsInvalid
+                }
+
+            }
+            return {
+                'validateString': validate
+            };
+        }());
+
         return {
             'toggleExpandCollapse': toggleExpandCollapse,
             'showLoadingIndicator': showLoadingIndicator,
@@ -186,6 +211,7 @@ define(["jquery", "underscore", "gettext", "js/views/feedback_notification", "js
             'setScrollOffset': setScrollOffset,
             'redirect': redirect,
             'reload': reload,
+            'keywordValidator': keywordValidator,
             'hasChangedAttributes': hasChangedAttributes
         };
     });

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -304,7 +304,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url}';
               <section class="group-settings">
                 <p>
                   ${_("Message for students who enroll {strong_start}before the start date{strong_end}").format(strong_start="<strong>", strong_end="</strong>")}
-                  <a class="send-test-email" id='test_email_pre' title="${_('Send me a copy of this via email')}" href="#">${_("Send me a test email")}</a>
+                  <a class="send-test-email" id='test_email_pre' title="${_('Send me a copy of this via email')}" href="#" data-endpoint="${test_email_url}">${_("Send me a test email")}</a>
                   <a class="fill-default-email" id='fill_default_email_pre' title="${_('Reset to default content')}" href="#">${_("Reset to default content")}</a>
                 </p>
                 <ol class="list-input">
@@ -324,7 +324,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url}';
               <section class="group-settings">
                 <p>
                   ${_("Message for students who enroll {strong_start}on or after the start date{strong_end}").format(strong_start="<strong>", strong_end="</strong>")}
-                  <a class="send-test-email" id='test_email_post' title="${_('Send me a copy of this via email')}" href="#">${_("Send me a test email")}</a>
+                  <a class="send-test-email" id='test_email_post' title="${_('Send me a copy of this via email')}" href="#" data-endpoint="${test_email_url}">${_("Send me a test email")}</a>
                   <a class="fill-default-email" id='fill_default_email_post' title="${_('Reset to default content')}" href="#">${_("Reset to default content")}</a>
                 </p>
                 <ol class="list-input">

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -92,7 +92,7 @@ urlpatterns += patterns(
     url(r'^settings/details/{}$'.format(settings.COURSE_KEY_PATTERN), 'settings_handler'),
     url(r'^settings/grading/{}(/)?(?P<grader_index>\d+)?$'.format(settings.COURSE_KEY_PATTERN), 'grading_handler'),
     url(r'^settings/advanced/{}$'.format(settings.COURSE_KEY_PATTERN), 'advanced_settings_handler'),
-    url(r'^settings/send_test_enrollment_email$', 'send_test_enrollment_email', name='send_test_enrollment_email'),
+    url(r'^settings/send_test_enrollment_email/{}$'.format(settings.COURSE_KEY_PATTERN), 'send_test_enrollment_email', name='send_test_enrollment_email'),
     url(r'^textbooks/{}$'.format(settings.COURSE_KEY_PATTERN), 'textbooks_list_handler'),
     url(r'^textbooks/{}/(?P<textbook_id>\d[^/]*)$'.format(settings.COURSE_KEY_PATTERN), 'textbooks_detail_handler'),
     url(r'^group_configurations/{}$'.format(settings.COURSE_KEY_PATTERN), 'group_configurations_list_handler'),

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -96,6 +96,7 @@ import dogstats_wrapper as dog_stats_api
 from util.db import commit_on_success_with_read_committed
 from util.json_request import JsonResponse
 from util.bad_request_rate_limiter import BadRequestRateLimiter
+from util.keyword_substitution import substitute_keywords_with_data
 
 from microsite_configuration import microsite
 
@@ -952,6 +953,7 @@ def notify_enrollment_by_email(course, user, request):
                 message = get_course_about_section(course, 'pre_enrollment_email')
 
             subject = ''.join(subject.splitlines())
+            message = substitute_keywords_with_data(message, user.id, course.id)
             user.email_user(subject, message, from_address)
 
         except Exception:

--- a/common/djangoapps/util/keyword_substitution.py
+++ b/common/djangoapps/util/keyword_substitution.py
@@ -5,7 +5,7 @@ Contains utility functions to help substitute keywords in a text body with
 the appropriate user / course data.
 
 Supported:
-    LMS:
+    LMS and CMS (email on enrollment):
         - %%USER_ID%% => anonymous user id
         - %%USER_FULLNAME%% => User's full name
         - %%COURSE_DISPLAY_NAME%% => display name of the course
@@ -16,8 +16,8 @@ Usage:
     above other modules in the dependency tree and acts like a global var.
     Then we can call substitute_keywords_with_data where substitution is
     needed. Currently called in:
-        - LMS: Announcements + Bulk emails
-        - CMS: Not called
+        - LMS: Bulk emails and emails on enrollment
+        - CMS: Sending test email on enrollment
 """
 
 from django.contrib.auth.models import User


### PR DESCRIPTION
In studio, an instructor can include keywords in their course enrollment email which will be automatically
substituted with the corresponding value for the recipient.
The keywords supported are:

%%USER_ID%% => anonymous_user_id
%%USER_FULLNAME%% => user profile name
%%COURSE_DISPLAY_NAME%% => display name of the course
%%COURSE_END_DATE%% => end date of the course

This uses the same validation code as the existing keyword validator for the LMS, but works with CMS which uses requirejs.

@jbau @stvstnfrd 