### PR TITLE
Fix access permissions for inline-analytics

### DIFF
--- a/common/djangoapps/xmodule_modifiers.py
+++ b/common/djangoapps/xmodule_modifiers.py
@@ -297,6 +297,7 @@ def add_inline_analytics(user, has_instructor_access, block, view, frag, context
             'answer_dist_url': reverse('get_analytics_answer_dist'),
             'responses_data': responses_data,
             'has_instructor_access': has_instructor_access,
+            'course_id': block.course_id.to_deprecated_string(),
         }
         return wrap_fragment(frag, render_to_string("inline_analytics.html", analytics_context))
 

--- a/lms/static/js/inline_analytics.js
+++ b/lms/static/js/inline_analytics.js
@@ -390,6 +390,7 @@ window.InlineAnalytics = (function() {
 
             var location = this.dataset.location;
             var answerDistUrl = this.dataset.answer_dist_url;
+            var courseId = this.dataset.course_id;
 
             // If data already retrieved for this problem, just show the div
             if (elementsRetrieved.indexOf(elementId) !== -1) {
@@ -432,6 +433,7 @@ window.InlineAnalytics = (function() {
             		module_id: location,
             		question_types_by_part: questionTypesByPart,
             		num_options_by_part: numOptionsByPart,
+            		course_id: courseId,
             };
 
             if (partsToGet.length > 0) {

--- a/lms/templates/inline_analytics.html
+++ b/lms/templates/inline_analytics.html
@@ -5,7 +5,7 @@ ${block_content}
 
 % if has_instructor_access:
   <div aria-hidden="true" class="wrap-instructor-info">
-    <a class="instructor-info-action instructor-analytics-action" id="${element_id}_analytics_button" data-location="${location}" data-answer_dist_url="${answer_dist_url}">${_("Staff Analytics Info")}</a>
+    <a class="instructor-info-action instructor-analytics-action" id="${element_id}_analytics_button" data-location="${location}" data-answer_dist_url="${answer_dist_url}" data-course_id="${course_id}">${_("Staff Analytics Info")}</a>
   </div>
 
   <div id="${element_id}_analytics_error_message" style="display: none;">


### PR DESCRIPTION
    Fix access permissions for inline-analytics
    
      Previously, the access was set to the auth_users.is_staff permission.
      This is different from the role of being a staff member of a course.
    
      Access is now such that the person running the in-line analytics report
      need only be a staff member of the course.
