### PR TITLE
  Fix for in-line analytics when name masks used.

### DIFF
--- a/lms/djangoapps/courseware/tests/test_inline_analytics_integration.py
+++ b/lms/djangoapps/courseware/tests/test_inline_analytics_integration.py
@@ -10,7 +10,6 @@ from courseware.views import get_analytics_answer_dist, process_analytics_answer
 from courseware.tests.factories import UserFactory, InstructorFactory, StaffFactory
 from xmodule.modulestore.tests.factories import CourseFactory
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
 
 class InlineAnalyticsTest(ModuleStoreTestCase):

--- a/lms/djangoapps/courseware/tests/test_inline_analytics_utils.py
+++ b/lms/djangoapps/courseware/tests/test_inline_analytics_utils.py
@@ -78,3 +78,41 @@ class ResponseTest(unittest.TestCase):
         self.assertEquals(response[1].response_type, 'radio')
         self.assertEquals(response[0].message, None)
         self.assertEquals(response[1].message, None)
+        self.assertEquals(response[0].choice_name_list, '[]')
+        self.assertEquals(response[1].choice_name_list, '[&quot;choice_0&quot;, &quot;choice_1&quot;, &quot;choice_2&quot;]')
+
+    def test_multi_responses_name_mask(self):
+
+        xml = textwrap.dedent("""\
+        <?xml version="1.0"?>
+        <problem>
+        <p>1st question</p>
+        <choiceresponse>
+            <checkboxgroup direction="vertical">
+                <choice correct="true">row 1</choice>
+                <choice correct="true">row 2</choice>
+                <choice correct="false">row 3</choice>
+            </checkboxgroup>
+        </choiceresponse>
+        <p>2nd question in the same problem:</p>
+        <multiplechoiceresponse>
+            <choicegroup type="MultipleChoice">
+                <choice correct="false" name="Tom">1st choice text</choice>
+                <choice correct="false" name="Dick">2nd choice text</choice>
+                <choice correct="true" name="Harry">3rd choice text</choice>
+            </choicegroup>
+        </multiplechoiceresponse>
+        </problem>
+        """)
+
+        module = CapaFactory.create(xml=xml)
+        response = get_responses_data(module)
+
+        self.assertEquals(response[0].correct_response, ['choice_0', 'choice_1'])
+        self.assertEquals(response[1].correct_response, ['choice_Harry'])
+        self.assertEquals(response[0].response_type, 'checkbox')
+        self.assertEquals(response[1].response_type, 'radio')
+        self.assertEquals(response[0].message, None)
+        self.assertEquals(response[1].message, None)
+        self.assertEquals(response[0].choice_name_list, '[]')
+        self.assertEquals(response[1].choice_name_list, '[&quot;choice_Tom&quot;, &quot;choice_Dick&quot;, &quot;choice_Harry&quot;]')

--- a/lms/templates/inline_analytics.html
+++ b/lms/templates/inline_analytics.html
@@ -4,8 +4,9 @@
 ${block_content}
 
 <div aria-hidden="true" class="wrap-instructor-info">
-  <a class="instructor-info-action instructor-analytics-action" id="${element_id}_analytics_button" data-location="${location}" data-answer_dist_url="${answer_dist_url}" data-course_id="${course_id}">${_("Staff Analytics Info")}</a>
+  <a class="instructor-info-action instructor-analytics-action" id="${element_id}_analytics_button" data-location="${location}" data-answer-dist-url="${answer_dist_url}" data-course-id="${course_id}">${_("Staff Analytics Info")}</a>
 </div>
+
 
 <div id="${element_id}_analytics_error_message" style="display: none;">
   <p><strong></strong></p>
@@ -14,13 +15,13 @@ ${block_content}
 <div id="${element_id}_analytics_close" style="display: none;" class="analytics_close_button" href="#">
   <button class="close">X</button>
 
-  % for part_id, correct_response, question_type, message in responses_data:
+  % for part_id, correct_response, question_type, message, choice_name_list in responses_data:
     % if message:
       <div id="${part_id}_analytics" class="${element_id}_analytics_div inline-analytics-item">${message}
         <p><strong></strong></p>
       </div>
     % elif question_type == 'radio':
-      <div id="${part_id}_analytics" class="${element_id}_analytics_div inline-analytics-item" data-correct_response="${correct_response}" data-question_type="${question_type}">
+      <div id="${part_id}_analytics" class="${element_id}_analytics_div inline-analytics-item" data-correct-response="${correct_response}" data-question-type="${question_type}" data-choice-name-list="${choice_name_list}">
         <section aria-hidden="true" >
           <div class="grid-wrapper radio">
             <p>Answer distribution of the <strong class="num-students"></strong> students who answered this question.</p>
@@ -38,7 +39,7 @@ ${block_content}
         </section>
       </div>
     % elif question_type == 'checkbox':
-      <div id="${part_id}_analytics" class="${element_id}_analytics_div inline-analytics-item" data-correct_response="${correct_response}" data-question_type="${question_type}">
+      <div id="${part_id}_analytics" class="${element_id}_analytics_div inline-analytics-item" data-correct-response="${correct_response}" data-question-type="${question_type}">
         <section aria-hidden="true" >
           <div class="grid-wrapper checkbox">
             <p>Answer distribution of the <strong class="num-students"></strong> students who answered this question:</p>
@@ -54,7 +55,7 @@ ${block_content}
         </section>
       </div>
     % else:
-      <div id="${part_id}_analytics" class="${element_id}_analytics_div" data-question_type="${question_type}">
+      <div id="${part_id}_analytics" class="${element_id}_analytics_div" data-question-type="${question_type}">
         <section aria-hidden="true" >
           <div class="grid-wrapper">
             <p>


### PR DESCRIPTION
    CS-103 have some questions which have been authored using the Latex
    Source Compiler. Unfortunately, this adds name attributes to the choices
    of MultipleChoiceResponse questions which affect the name of the option
    chosen by the student.

    This overrides the default names and causes a mis-match between the default
    name and that stored in the analytics data pipeline.

    This PR allows name masking to be used and not affect in-line analytics.