### PR TITLE
Make keyword substitution discoverable in bulk email

### DIFF
--- a/lms/static/coffee/src/instructor_dashboard/send_email.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/send_email.coffee
@@ -34,6 +34,7 @@ class SendEmail
     @$email_messages_wrapper = @$container.find(".email-messages-wrapper")
 
     # attach click handlers
+    accessible_modal(".keyword-sub-link", ".keyword-sub-modal .close-modal", ".keyword-sub-modal", "#section-send-email")
 
     @$btn_send.click =>
       if @$subject.val() == ""

--- a/lms/static/sass/shared/_modal.scss
+++ b/lms/static/sass/shared/_modal.scss
@@ -51,6 +51,10 @@
     }
   }
 
+  &.keyword-sub-modal {
+    width: grid-width(7);
+  }
+
   .inner-wrapper {
     background: $modal-bg-color;
     border-radius: 0px;
@@ -300,7 +304,7 @@
     }
   }
 
-  #help_wrapper, .discussion-alert-wrapper {
+  #help_wrapper, .keyword-sub-wrapper, .discussion-alert-wrapper {
     padding: 0 ($baseline*1.5) ($baseline*1.5) ($baseline*1.5);
 
     header {
@@ -332,7 +336,20 @@
     color: $dark-gray;
   }
 
+  .keyword-sub-wrapper table {
+    width: 100%;
+    margin-top: $baseline;
+    color: $base-font-color;
+    td {
+      border: 1px solid black;
+      padding: $baseline/2;
+      vertical-align: middle;
 
+      input {
+        width: 100%;
+      }
+    }
+  }
 }
 
 .leanModal_box {

--- a/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
+++ b/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
@@ -118,3 +118,6 @@
     </section>
   </div>
 </section>
+
+## Modal included here so leanModal can position it outside of dashboard wrapper
+<%include file='keyword_sub_modal.html' />

--- a/lms/templates/instructor/instructor_dashboard_2/keyword_sub_modal.html
+++ b/lms/templates/instructor/instructor_dashboard_2/keyword_sub_modal.html
@@ -1,0 +1,47 @@
+<%! from django.utils.translation import ugettext as _ %>
+
+<section id="keyword-sub-modal" class="modal keyword-sub-modal" aria-hidden="true">
+  <div class="inner-wrapper keyword-sub-wrapper" role="dialog" aria-labelledby="keyword-sub-tip-title">
+    <button class="close-modal">
+      <i class="icon-remove"></i>
+      <span class="sr">
+        ## Translators: this is a control to allow users to exit out of this modal interface (a menu or piece of UI that takes the full focus of the screen)
+        ${_("Close")}
+      </span>
+    </button>
+
+    <header>
+      <h2 id="keyword-sub-tip-title">
+        ${_("Keyword Substitution")}
+        <span class="sr">,
+          ## Translators: this text gives status on if the modal interface (a menu or piece of UI that takes the full focus of the screen) is open or not
+          ${_("window open")}
+        </span>
+      </h2>
+      <hr/>
+    </header>
+
+    <p>
+      ${_("Copy and paste keywords on the left into your email message. They will be replaced by the values on the right for each student when the email is sent.")}
+    </p>
+    <table>
+      <tr>
+        <td><input type="text" value="%%USER_FULLNAME%%" readonly="readonly" /></td>
+        <td>${_("user profile name")}</td>
+      </tr>
+      <tr>
+        <td><input type="text" value="%%USER_ID%%" readonly="readonly" /></td>
+        <td>${_("anonymous_user_id (for use in survey links)")}</td>
+      </tr>
+      <tr>
+        <td><input type="text" value="%%COURSE_DISPLAY_NAME%%" readonly="readonly" /></td>
+        <td>${_("display name of the course")}</td>
+      </tr>
+      <tr>
+        <td><input type="text" value="%%COURSE_END_DATE%%" readonly="readonly" /></td>
+        <td>${_("end date of the course")}</td>
+      </tr>
+    </table>
+
+  </div>
+</section>

--- a/lms/templates/instructor/instructor_dashboard_2/send_email.html
+++ b/lms/templates/instructor/instructor_dashboard_2/send_email.html
@@ -33,6 +33,7 @@
   </li>
   <li class="field">
     <label>${_("Message:")}</label>
+    <span class="tip"><a href="#keyword-sub-modal" class="keyword-sub-link" rel="leanModal">${_("Supports keyword substitutions")}</a></span>
       <div class="email-editor">
       ${ section_data['editor'] }
       </div>


### PR DESCRIPTION
Adds a tip under the Message label in bulk email, which links to modal that explains how to use keyword substitutions.

@caesar2164 @stvstnfrd @jbau 