### PR TITLE
Add keyword substitution for course announcements

### DIFF
--- a/cms/static/js/views/course_info_update.js
+++ b/cms/static/js/views/course_info_update.js
@@ -1,6 +1,6 @@
 define(["js/views/baseview", "codemirror", "js/models/course_update",
-    "js/views/feedback_prompt", "js/views/feedback_notification", "js/views/course_info_helper", "js/utils/modal"],
-    function(BaseView, CodeMirror, CourseUpdateModel, PromptView, NotificationView, CourseInfoHelper, ModalUtils) {
+    "js/views/feedback_prompt", "js/views/feedback_notification", "js/views/course_info_helper", "js/utils/modal", "js/views/utils/view_utils"],
+    function(BaseView, CodeMirror, CourseUpdateModel, PromptView, NotificationView, CourseInfoHelper, ModalUtils, ViewUtils) {
 
     var CourseInfoUpdateView = BaseView.extend({
         // collection is CourseUpdateCollection
@@ -73,6 +73,13 @@ define(["js/views/baseview", "codemirror", "js/models/course_update",
 
         onSave: function(event) {
             event.preventDefault();
+            var validation = ViewUtils.keywordValidator.validateString(this.$codeMirror.getValue());
+            if (!validation.isValid) {
+                message = gettext('There are invalid keywords in your message. Please check the following keywords and try again:');
+                message += "\n" + validation.keywordsInvalid.join('\n');
+                window.alert(message);
+                return;
+            }
             var targetModel = this.eventModel(event);
             targetModel.set({ date : this.dateEntry(event).val(), content : this.$codeMirror.getValue() });
             // push change to display, hide the editor, submit the change

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -17,6 +17,7 @@ from static_replace import replace_static_urls
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.x_module import STUDENT_VIEW
 from microsite_configuration import microsite
+from util.keyword_substitution import substitute_keywords_with_data
 
 from courseware.access import has_access
 from courseware.model_data import FieldDataCache
@@ -285,6 +286,7 @@ def get_course_info_section(request, course, section_key):
     if info_module is not None:
         try:
             html = info_module.render(STUDENT_VIEW).content
+            html = substitute_keywords_with_data(html, request.user.id, course.id)
         except Exception:  # pylint: disable=broad-except
             html = render_to_string('courseware/error-message.html', None)
             log.exception(


### PR DESCRIPTION
In studio, users will be able to use keywords in their course updates, and they will substituted with their corresponding values when students view the updates in LMS. Supports the same keywords as bulk email and email on enrollment.

@jbau 