### PR TITLE
  Fix for bug in inline-analytics found on stage

### DIFF
--- a/lms/static/js/inline_analytics.js
+++ b/lms/static/js/inline_analytics.js
@@ -106,6 +106,7 @@ window.InlineAnalytics = (function() {
         var valueIdArray;
         var arrayLength;
         var lastRow = $('#' + partId + '_table tr:last');
+        var currentResult;
 
         // Build the array of choice texts
         var choiceText = getChoiceTexts(partId);
@@ -133,8 +134,9 @@ window.InlineAnalytics = (function() {
                 	    choiceNameArray,
                 	    trs);
                 } else {
-                    correct = result[index]['correct'];
-                    count = result[index]['count'];
+                    currentResult = result[valueIdArray.indexOf(choiceNameArray[index])]
+                    correct = currentResult['correct'];
+                    count = currentResult['count'];
                     percent = Math.round(count * 1000 / (totalAttemptCount * 10));
 
                     if (correct) {


### PR DESCRIPTION
    When there were no student responses for a choice it was possible
    to cause an error. This was caused by the new code that handled name
    masks.

    It turned out that there was still a piece of legacy code that expected
    the result index to start zero.