### PR TITLE
Rename links to 'Help Center'

### DIFF
--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -142,7 +142,7 @@
                     <a href="http://edx.readthedocs.org/projects/ca/en/latest/">${_("Studio Documentation")}</a>
                   </li>
                   <li class="nav-item nav-help-helpcenter">
-                    <a href="https://stanfordonline.zendesk.com/hc" target="_blank" rel="external">${_("studio-users group")}</a>
+                    <a href="https://stanfordonline.zendesk.com/hc" target="_blank" rel="external">${_("Help Center")}</a>
                   </li>
                   <li class="nav-item nav-help-feedback">
                     <a href="mailto:courseops@stanfordonline.zendesk.com" title="${_("Share your feedback with us.")}">${_("Contact Us")}</a>

--- a/cms/templates/widgets/sock.html
+++ b/cms/templates/widgets/sock.html
@@ -31,8 +31,8 @@
           <span class="tip">${_("How to use Studio to build your course")}</span>
         </li>
         <li class="action-item">
-          <a href="https://stanfordonline.zendesk.com/hc" rel="external" class="action action-primary">${_("studio-users group")}</a>
-          <span class="tip"><i class="ss-icon ss-symbolicons-block icon-help">&#xEE11;</i> ${_("studio-users group")}</span>
+          <a href="https://stanfordonline.zendesk.com/hc" rel="external" class="action action-primary">${_("Help Center")}</a>
+          <span class="tip"><i class="ss-icon ss-symbolicons-block icon-help">&#xEE11;</i> ${_("Find answers in the FAQ or ask a new question.")}</span>
         </li>
         <li class="action-item">
           <a href="https://edge.edx.org/courses/edX/edX101/How_to_Create_an_edX_Course/about" rel="external" class="action action-primary">${_("Enroll in edX101")}</a>


### PR DESCRIPTION
- Links to the help center are now named properly
- Link to actual studio-users group remains the same

@stvstnfrd & @jinpa 