### PR TITLE
Change Insights from gray box callout to menu link

### DIFF
--- a/lms/djangoapps/instructor/tests/test_ecommerce.py
+++ b/lms/djangoapps/instructor/tests/test_ecommerce.py
@@ -34,7 +34,7 @@ class TestECommerceDashboardViews(ModuleStoreTestCase):
         mode.save()
         # URL for instructor dash
         self.url = reverse('instructor_dashboard', kwargs={'course_id': self.course.id.to_deprecated_string()})
-        self.e_commerce_link = '<a href="" data-section="e-commerce">E-Commerce</a>'
+        self.e_commerce_link = '<a href="#" class="instructor-dashboard-link" data-section="e-commerce">E-Commerce</a>'
         CourseFinanceAdminRole(self.course.id).add_users(self.instructor)
 
     def tearDown(self):

--- a/lms/djangoapps/instructor/tests/test_email.py
+++ b/lms/djangoapps/instructor/tests/test_email.py
@@ -37,7 +37,7 @@ class TestNewInstructorDashboardEmailViewMongoBacked(ModuleStoreTestCase):
         # URL for instructor dash
         self.url = reverse('instructor_dashboard', kwargs={'course_id': self.course.id.to_deprecated_string()})
         # URL for email view
-        self.email_link = '<a href="" data-section="send_email">Email</a>'
+        self.email_link = '<a href="#" class="instructor-dashboard-link" data-section="send_email">Email</a>'
 
     def tearDown(self):
         """

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -93,14 +93,10 @@ def instructor_dashboard_2(request, course_id):
 
     disable_buttons = not _is_small_course(course_key)
 
-    analytics_dashboard_message = None
+    insights_dashboard_url = None
     if settings.ANALYTICS_DASHBOARD_URL:
         # Construct a URL to the external analytics dashboard
-        analytics_dashboard_url = '{0}/courses/{1}'.format(settings.ANALYTICS_DASHBOARD_URL, unicode(course_key))
-        link_start = "<a href=\"{}\" target=\"_blank\">".format(analytics_dashboard_url)
-        analytics_dashboard_message = _("To gain insights into student enrollment and participation {link_start}visit {analytics_dashboard_name}, our new course analytics product{link_end}.")
-        analytics_dashboard_message = analytics_dashboard_message.format(
-            link_start=link_start, link_end="</a>", analytics_dashboard_name=settings.ANALYTICS_DASHBOARD_NAME)
+        insights_dashboard_url = '{0}/courses/{1}'.format(settings.ANALYTICS_DASHBOARD_URL, unicode(course_key))
 
     context = {
         'course': course,
@@ -108,7 +104,7 @@ def instructor_dashboard_2(request, course_id):
         'studio_url': get_studio_url(course, 'course'),
         'sections': sections,
         'disable_buttons': disable_buttons,
-        'analytics_dashboard_message': analytics_dashboard_message
+        'insights_dashboard_url': insights_dashboard_url,
     }
 
     return render_to_response('instructor/instructor_dashboard_2/instructor_dashboard_2.html', context)

--- a/lms/static/coffee/src/instructor_dashboard/instructor_dashboard.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/instructor_dashboard.coffee
@@ -91,7 +91,7 @@ $ =>
 # handles hiding and showing sections
 setup_instructor_dashboard = (idash_content) =>
   # clickable section titles
-  $links = idash_content.find(".#{CSS_INSTRUCTOR_NAV}").find('a')
+  $links = idash_content.find(".#{CSS_INSTRUCTOR_NAV}").find('a.instructor-dashboard-link')
 
   # attach link click handlers
   $links.each (i, link) ->

--- a/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
+++ b/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
@@ -89,13 +89,6 @@
       </div>
 
     <h1>${_("Instructor Dashboard")}</h1>
-
-      %if analytics_dashboard_message:
-        <div class="wrapper-msg urgency-low is-shown">
-            <p>${analytics_dashboard_message}</p>
-        </div>
-      %endif
-
     ## links which are tied to idash-sections below.
     ## the links are activated and handled in instructor_dashboard.coffee
     ## when the javascript loads, it clicks on the first section
@@ -103,8 +96,13 @@
       % for section_data in sections:
         ## This is necessary so we don't scrape 'section_display_name' as a string.
         <% dname = section_data['section_display_name'] %>
-        <li class="nav-item"><a href="" data-section="${ section_data['section_key'] }">${_(dname)}</a></li>
+        <li class="nav-item">
+            <a href="#" class="instructor-dashboard-link" data-section="${ section_data['section_key'] }">${_(dname)}</a>
+        </li>
       % endfor
+      %if insights_dashboard_url:
+        <li class="nav-item"><a href="${insights_dashboard_url}" target="_blank">${_("Insights")}</a></li>
+      % endif
     </ul>
 
     ## each section corresponds to a section_data sub-dictionary provided by the view


### PR DESCRIPTION
- removed python code that rendered HTML gray box
- changed variable being passed from views -> html

@stvstnfrd & @dcadams - python and mako/html code changes to achieve this:

![insights-link](https://cloud.githubusercontent.com/assets/3364609/6007353/3575bc8e-aace-11e4-91eb-949a36439d05.png)
