### PR TITLE
Exclude course /about /info and / from direct access

### DIFF
--- a/lms/djangoapps/sneakpeek_deeplink/middleware.py
+++ b/lms/djangoapps/sneakpeek_deeplink/middleware.py
@@ -10,7 +10,14 @@ from util.request import course_id_from_url
 from courseware.models import CoursePreference
 from student.views import _create_and_login_nonregistered_user, _check_can_enroll_in_course
 
-DISALLOW_SNEAKPEEK_URL_NAMES = ('lti_rest_endpoints', 'xblock_handler_noauth', 'xqueue_callback')
+DISALLOW_SNEAKPEEK_URL_NAMES = (
+    'lti_rest_endpoints',
+    'xblock_handler_noauth',
+    'xqueue_callback',
+    'about_course',
+    'course_root',
+    'info',
+)
 
 
 class SneakPeekDeepLinkMiddleware(object):


### PR DESCRIPTION
@stvstnfrd 

This prevents course `/about`, `/info`, and `/` pages from creating direct access users.

Also some opportunistic import cleanup