### PR TITLE
Add tab to Sysadmin Dashboard to fix bad queue tasks.

### DIFF
--- a/lms/djangoapps/dashboard/sysadmin_urls.py
+++ b/lms/djangoapps/dashboard/sysadmin_urls.py
@@ -15,4 +15,5 @@ urlpatterns = patterns(
     url(r'^gitlogs/?$', sysadmin.GitLogs.as_view(), name="gitlogs"),
     url(r'^gitlogs/(?P<course_id>.+)$', sysadmin.GitLogs.as_view(),
         name="gitlogs_detail"),
+    url(r'^task_queue/?$', sysadmin.TaskQueue.as_view(), name="sysadmin_task_queue"),
 )

--- a/lms/templates/sysadmin_dashboard.html
+++ b/lms/templates/sysadmin_dashboard.html
@@ -58,6 +58,7 @@ textarea {
       <a href="${reverse('sysadmin_staffing')}" class="${modeflag.get('staffing')}">${_('Staffing and Enrollment')}</a> 
       ## Translators: refers to http://git-scm.com/docs/git-log
       <a href="${reverse('gitlogs')}">${_('Git Logs')}</a>
+      <a href="${reverse('sysadmin_task_queue')}" class="${modeflag.get('task_queue')}">${_('Task Queue')}</a>
     </h2>
 	<hr />
 %if modeflag.get('users'):
@@ -161,6 +162,29 @@ textarea {
   </div>
 </form>
 <hr style="width:40%" />
+%endif
+
+%if modeflag.get('task_queue'):
+  <h3>${_('Kill Queuing Tasks')}</h3><br/>
+
+  <form name="action" method="POST">
+    <input type="hidden" name="csrfmiddlewaretoken" value="${ csrf_token }" />
+
+    <ul class="list-input">
+      <li class="field text" style="padding-bottom: 1.2em">
+        <label for="row_id">${_('ID of row in instructor_task_instructortask')}</label>
+        <input type="text" name="row_id" size=40 />
+      </li>
+    </ul>
+
+    <div class="form-actions">
+      <p>
+        <button type="submit" name="action" value="kill_task">${_('Kill task')}</button>
+      </p>
+    </div>
+
+    <hr />
+  </form>
 %endif
 
 %if msg:

--- a/lms/templates/sysadmin_dashboard_gitlogs.html
+++ b/lms/templates/sysadmin_dashboard_gitlogs.html
@@ -62,6 +62,7 @@ textarea {
         <a href="${reverse('sysadmin_staffing')}">${_('Staffing and Enrollment')}</a>
         ## Translators: refers to http://git-scm.com/docs/git-log
         <a href="${reverse('gitlogs')}" class="active-section">${_('Git Logs')}</a>
+        <a href="${reverse('sysadmin_task_queue')}">${_('Task Queue')}</a>
       </h2>
       <hr />
 


### PR DESCRIPTION
On occasion, mainly after a release, it has been found that
entries in the instructor_task_instructortask table get
stuck with a task_state of QUEUING.

This PR enables a course staff member to change the state
of said entry and so allow other tasks to run.