### PR TITLE
Bug fixes for email-widget including firefox compatibility and bulk-email query deletion

### DIFF
--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -434,7 +434,7 @@ class TestEmailQueries(ModuleStoreTestCase, LoginEnrollmentTestCase):
         saved_queries = self._get_saved_queries()
         self.assertEquals(len(saved_queries), 2)
         query_group = saved_queries[0]['group']
-        #purge these temporary queries to have a clean table
+        # purge these temporary queries to have a clean table
         TemporaryQuery.objects.all().delete()
         self.assertEquals(0, len(TemporaryQuery.objects.all()))
         students = get_group_query_students(self.course_key, query_group)

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -88,7 +88,7 @@ from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from opaque_keys import InvalidKeyError
 from student.models import UserProfile, Registration
 import instructor.views.data_access as data_access
-from instructor.views.data_access_constants import QueryType, StudentQuery
+from instructor.views.data_access_constants import QueryType, StudentQuery, QUERYORIGIN_MAP, QueryOrigin
 from instructor.views.data_access_constants import REVERSE_INCLUSION_MAP, INCLUDE_SECTION_PATTERN
 from instructor.views.data_access_constants import INCLUDE_PROBLEM_PATTERN, ALL_PROBLEM_FILTERS, ALL_SECTION_FILTERS
 from instructor.tasks import make_single_query
@@ -886,17 +886,19 @@ def get_temp_queries(request, course_id):  # pylint: disable=unused-argument
     course_id = SlashSeparatedCourseKey.from_deprecated_string(course_id)
     saved_temp = data_access.get_temp_queries(course_id)
     cleaned_queries = []
+
     for query in saved_temp:
-        cleaned_queries.append({
-            'id': query.id,
-            'inclusion': REVERSE_INCLUSION_MAP[query.inclusion],
-            'block_type': query.module_state_key.block_type,
-            'block_id': query.module_state_key.block_id,
-            'filter_on': query.filter_on,
-            'display_name': query.entity_name,
-            'type': query.query_type,
-            'done': query.done,
-        })
+        if query.origin == QUERYORIGIN_MAP[QueryOrigin.WIDGET]:
+            cleaned_queries.append({
+                'id': query.id,
+                'inclusion': REVERSE_INCLUSION_MAP[query.inclusion],
+                'block_type': query.module_state_key.block_type,
+                'block_id': query.module_state_key.block_id,
+                'filter_on': query.filter_on,
+                'display_name': query.entity_name,
+                'type': query.query_type,
+                'done': query.done,
+            })
     response_payload = {
         'course_id': course_id.to_deprecated_string(),
         'queries': cleaned_queries,

--- a/lms/djangoapps/instructor/views/data_access.py
+++ b/lms/djangoapps/instructor/views/data_access.py
@@ -79,7 +79,6 @@ def get_group_query_students(course_id, group_id):
     _group, queries, _relation = get_saved_queries(course_id, group_id)
     # wait for the queries to finish before proceeding
     make_subqueries.apply_async(args=(course_id, group_id, queries)).get()
-    # forcing evaluation here because we will be deleting stuff afterward
     subqueries_qs = GroupedTempQueryForSubquery.objects.filter(grouped_id=group_id).distinct().values_list('query',
                                                                                                            flat=True)
     if subqueries_qs:
@@ -103,7 +102,7 @@ def retrieve_grouped_query(course_id, group_id):
     if not student_info:
         return StudentsForQuery.objects.none()
     students = student_info.distinct()
-    #forcing evaluation on students because we'll be deleting the intermediate queries
+    # forcing evaluation on students because we'll be deleting the intermediate queries
     len(students)
     subqueries_ids = subqueries.values_list('query', flat=True)
     old_queries = TemporaryQuery.objects.filter(id__in=list(subqueries_ids))

--- a/lms/djangoapps/instructor/views/data_access_constants.py
+++ b/lms/djangoapps/instructor/views/data_access_constants.py
@@ -16,6 +16,16 @@ class StudentQuery(object):
         self.entity_name = entity_name
 
 
+class QueryOrigin:
+    """
+    Where a query issued originated
+    """
+    EMAIL = "EMAIL"
+    WIDGET = "WIDGET"
+
+QUERYORIGIN_MAP = {QueryOrigin.EMAIL: 'E',
+                   QueryOrigin.WIDGET: 'W'}
+
 class Inclusion:
     """
     Options for combining queries

--- a/lms/djangoapps/instructor_email_widget/models.py
+++ b/lms/djangoapps/instructor_email_widget/models.py
@@ -14,7 +14,7 @@ ASSUMPTIONS: modules have unique IDs, even across different module_types
 """
 from django.contrib.auth.models import User
 from django.db import models
-from instructor.views.data_access_constants import Inclusion
+from instructor.views.data_access_constants import Inclusion, QueryOrigin, QUERYORIGIN_MAP
 from xmodule_django.models import CourseKeyField, LocationKeyField
 
 
@@ -75,6 +75,11 @@ class TemporaryQuery(models.Model):
     created = models.DateTimeField(auto_now_add=True, null=True, db_index=True)
     entity_name = models.CharField(max_length=255)
     query_type = models.CharField(max_length=255)
+    ORIGIN = (
+        ('E', QueryOrigin.EMAIL),
+        ('W', QueryOrigin.WIDGET),
+    )
+    origin = models.CharField(default=QUERYORIGIN_MAP[QueryOrigin.WIDGET], max_length=1, choices=ORIGIN)
     done = models.NullBooleanField()
 
     def __unicode__(self):

--- a/lms/static/coffee/src/instructor_dashboard/membership.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/membership.coffee
@@ -146,7 +146,7 @@ class AuthListWidget extends MemberListWidget
       data: rolename: @rolename
       success: (data) => cb? null, data[@rolename]
       error: std_ajax_err =>
-        `// Translators: A rolename appears this sentence. A rolename is something like "staff" or "beta tester".`
+        # Translators: A rolename appears this sentence. A rolename is something like "staff" or "beta tester".
         cb? gettext("Error fetching list for role") + " '#{@rolename}'"
 
   # send ajax request to modify access
@@ -350,24 +350,24 @@ class BetaTesterBulkAddition
       @$task_response.append task_res_section
 
     if successes.length and data_from_server.action is 'add'
-      `// Translators: A list of users appears after this sentence`
+      # Translators: A list of users appears after this sentence
       render_list gettext("These users were successfully added as beta testers:"), (sr.identifier for sr in successes)
 
     if successes.length and data_from_server.action is 'remove'
-      `// Translators: A list of users appears after this sentence`
+      #Translators: A list of users appears after this sentence
       render_list gettext("These users were successfully removed as beta testers:"), (sr.identifier for sr in successes)
 
     if errors.length and data_from_server.action is 'add'
-      `// Translators: A list of users appears after this sentence`
+      # Translators: A list of users appears after this sentence
       render_list gettext("These users were not added as beta testers:"), (sr.identifier for sr in errors)
 
     if errors.length and data_from_server.action is 'remove'
-      `// Translators: A list of users appears after this sentence`
+      # Translators: A list of users appears after this sentence
       render_list gettext("These users were not removed as beta testers:"), (sr.identifier for sr in errors)
 
     if no_users.length
       no_users.push $ gettext("Users must create and activate their account before they can be promoted to beta tester.")
-      `// Translators: A list of identifiers (which are email addresses and/or usernames) appears after this sentence`
+      # Translators: A list of identifiers (which are email addresses and/or usernames) appears after this sentence
       render_list gettext("Could not find users associated with the following identifiers:"), (sr.identifier for sr in no_users)
 
 # Wrapper for the batch enrollment subsection.
@@ -523,45 +523,45 @@ class BatchEnrollment
       render_list gettext("Successfully enrolled and sent email to the following users:"), (sr.identifier for sr in enrolled)
 
     if enrolled.length and not emailStudents
-      `// Translators: A list of users appears after this sentence`
+      # Translators: A list of users appears after this sentence
       render_list gettext("Successfully enrolled the following users:"), (sr.identifier for sr in enrolled)
 
     # Student hasn't registered so we allow them to enroll
     if allowed.length and emailStudents
-      `// Translators: A list of users appears after this sentence`
+      # Translators: A list of users appears after this sentence
       render_list gettext("Successfully sent enrollment emails to the following users. They will be allowed to enroll once they register:"),
         (sr.identifier for sr in allowed)
 
     # Student hasn't registered so we allow them to enroll
     if allowed.length and not emailStudents
-      `// Translators: A list of users appears after this sentence`
+      # Translators: A list of users appears after this sentence
       render_list gettext("These users will be allowed to enroll once they register:"),
         (sr.identifier for sr in allowed)
 
     # Student hasn't registered so we allow them to enroll with autoenroll
     if autoenrolled.length and emailStudents
-      `// Translators: A list of users appears after this sentence`
+      # Translators: A list of users appears after this sentence
       render_list gettext("Successfully sent enrollment emails to the following users. They will be enrolled once they register:"),
         (sr.identifier for sr in autoenrolled)
 
     # Student hasn't registered so we allow them to enroll with autoenroll
     if autoenrolled.length and not emailStudents
-      `// Translators: A list of users appears after this sentence`
+      # Translators: A list of users appears after this sentence
       render_list gettext("These users will be enrolled once they register:"),
         (sr.identifier for sr in autoenrolled)
 
     if notenrolled.length and emailStudents
-      `// Translators: A list of users appears after this sentence`
+      # Translators: A list of users appears after this sentence
       render_list gettext("Emails successfully sent. The following users are no longer enrolled in the course:"),
         (sr.identifier for sr in notenrolled)
 
     if notenrolled.length and not emailStudents
-      `// Translators: A list of users appears after this sentence`
+      # Translators: A list of users appears after this sentence
       render_list gettext("The following users are no longer enrolled in the course:"),
         (sr.identifier for sr in notenrolled)
 
     if notunenrolled.length
-      `// Translators: A list of users appears after this sentence. This situation arises when a staff member tries to unenroll a user who is not currently enrolled in this course.`
+      # Translators: A list of users appears after this sentence. This situation arises when a staff member tries to unenroll a user who is not currently enrolled in this course.
       render_list gettext("These users were not affiliated with the course so could not be unenrolled:"),
         (sr.identifier for sr in notunenrolled)
 
@@ -768,22 +768,22 @@ class EmailWidget
     for emailList in emailLists
       emailList.$container.addClass('active')
 
-    @$getEstBtn = $section.find("input[name='getest']'")
+    @$getEstBtn = $section.find("input[name='getest']")
     @$getEstBtn.click () =>
       @reload_estimated()
 
-    @$startoverBtn = $section.find("input[name='startover']'")
+    @$startoverBtn = $section.find("input[name='startover']")
     @$startoverBtn.click () =>
       @delete_temporary()
       $('.emailWidget.queryTableBody tr').remove()
       @reload_estimated()
 
-    @$saveQueryBtn = $section.find("input[name='savequery']'")
+    @$saveQueryBtn = $section.find("input[name='savequery']")
     @$saveQueryBtn.click () =>
       @send_save_query()
 
-    @$emailCsvBtn = $section.find("input[name='getcsv']'")
-    @$emailCsvBtn.click () =>
+    @$emailCsvBtn = $section.find("input[name='getcsv']")
+    @$emailCsvBtn.click (event) =>
       rows = $('.emailWidget.queryTableBody tr')
       sendingQuery = _.map (rows), (row) =>
           row.getAttribute('query')
@@ -805,7 +805,7 @@ class EmailWidget
     )
     poller.start()
 
-    $('.emailWidget.addQuery').click =>
+    $('.emailWidget.addQuery').click (event) =>
       $selected = @$emailListContainers.find('select.single-email-selector option:selected')
         #.children('option:selected')
       # check to see if stuff has been filled out
@@ -929,8 +929,8 @@ class EmailWidget
         time = ''
         for query in savedQs
           cells = query.children
-          types.push(cells[0].innerText)
-          names.push(cells[2].innerText)
+          types.push(jQuery(cells[0]).text())
+          names.push(jQuery(cells[2]).text())
           time = query.getAttribute('created')
         savedQueryDisplayName = ''
         for i in [0..types.length-1]
@@ -982,7 +982,7 @@ class EmailWidget
         cell.id = item['id']
     $loadBtn = $ _.template('<div class="loadQuery"><i class="icon-upload">
       </i> <%= label %></div>', {label: 'Load'})
-    $loadBtn.click =>
+    $loadBtn.click (event) =>
       @delete_temporary()
       $('.emailWidget.queryTableBody tr').remove()
       targ = event.target
@@ -995,14 +995,14 @@ class EmailWidget
       rowsToAdd = $('.saved' + groupedQueryId)
       for row in rowsToAdd
         cells = row.children
-        savedQueryOptions = [{'text':cells[0].innerText},
-                {'text':cells[1].innerText},
-                {'text':cells[2].innerText, 'id':cells[2].id},
-                {'text':cells[3].innerText}]
+        savedQueryOptions = [{'text': jQuery(cells[0]).text()},
+                {'text': jQuery(cells[1]).text()},
+                {'text': jQuery(cells[2]).text(), 'id':cells[2].id},
+                {'text': jQuery(cells[3]).text()}]
 
-        savedQueryOptionsText = [cells[0].innerText, cells[1].innerText,
-                     cells[2].innerText, cells[3].innerText]
-        @tr = @start_row(cells[0].innerText.toLowerCase(),
+        savedQueryOptionsText = [jQuery(cells[0]).text(), jQuery(cells[1]).text(),
+                     jQuery(cells[2]).text(), jQuery(cells[3]).text()]
+        @tr = @start_row( jQuery(cells[0]).text().toLowerCase(),
           savedQueryOptions,'', $('.emailWidget.queryTableBody'))
         # todo:this feels too hacky. suggestions?
         @useQueryEndpoint = [
@@ -1022,7 +1022,8 @@ class EmailWidget
     row.appendChild($td[0])
     $deleteBtn = $(_.template('<div class="deleteSaved">
       <i class="icon-remove-sign"></i> <%= label %></div>', {label: 'Delete'}))
-    $deleteBtn.click =>
+
+    $deleteBtn.click (event) =>
       targ = event.target
       while (!targ.classList.contains('deleteSaved'))
         targ = targ.parentNode
@@ -1162,7 +1163,7 @@ class EmailWidget
         progressCell.innerHTML = $progress_icon[0].outerHTML
     $removeBtn = $(_.template('<div class="remove"><i class="icon-remove-sign">
       </i> <%= label %></div>', {label: 'Remove'}))
-    $removeBtn.click =>
+    $removeBtn.click (event) =>
       targ = event.target
       while (!targ.classList.contains('remove'))
         targ = targ.parentNode

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -252,6 +252,7 @@
   %endif
 </div>
 
+<hr class="divider" />
 
 <div
     class="email-lists-management"
@@ -266,14 +267,13 @@
     <div class="header">
         <h2 class="title">${_("Email Distribution")}</h2>
     </div>
-    <label for="beginning_specific">
+    <div>
         ${_("Select criteria on which to generate a list of student emails. "
         "Please clear the active queries or load your saved work if you "
         "are inactive for more than 15 minutes, otherwise queries might "
         "be inaccurate. If the status gets stuck at 'working' for a long "
         "time, you may come back to the page later.")}
-
-    </label>
+    </div>
     <div class="email-list">
         <div class="email-list-container"
              data-label="${_("Inclusion")}"
@@ -366,7 +366,7 @@
         <div>${_("NOT, Problem 3, Opened")}</div>
         <div>${_("OR, Problem 2, Not Opened")}</div>
         <div>${_("Returns: Students who have opened Problem 1 and not completed Problem 2, but have not opened Problem"
-            " 3 in addition to students who have not opened Problem 4")}<br/><br/>
+            " 3 in addition to students who have not opened Problem 2")}<br/><br/>
             ${_("The intersection of <i>AND</i> queries is taken.")}<br/>
             ${_("The union of <i>NOT</i> queries is taken")} <br/>
             ${_("The union of <i>OR</i> queries is taken")} <br/>


### PR DESCRIPTION
Bug fixes for email widget
Added a field called "origin"

includes:
Fixing firefox incompatibilities: 
        remove query is now clickable (firefox doesn't support event.target)
        description text is fixed (firefox doesn't have  .innertext) 
Fixed erroneous wording
Fixed hovering over the description text--now doesn't look like it's clickable
Fixed the bulk email flow. Before, queries would show up in the GUI while the emails were sending. Now, they wont show up and we are more efficient in handling their deletion

tagging @kluo for email stuff, @caesar2164  for coffeescript