### PR TITLE
Fix inline analytics after date format was deprecated.

### DIFF
--- a/lms/djangoapps/courseware/tests/test_inline_analytics_integration.py
+++ b/lms/djangoapps/courseware/tests/test_inline_analytics_integration.py
@@ -101,7 +101,7 @@ class InlineAnalyticsTest(ModuleStoreTestCase):
                 "answer_value_text": "Option 1",
                 "answer_value_numeric": "null",
                 "variant": None,
-                "created": "2014-10-15T10:13:51",
+                "created": "2014-10-15T101351",
             },
             {
                 "course_id": "A/B/C",
@@ -113,7 +113,7 @@ class InlineAnalyticsTest(ModuleStoreTestCase):
                 "answer_value_text": "Option 2",
                 "answer_value_numeric": "null",
                 "variant": None,
-                "created": "2014-10-15T10:13:51",
+                "created": "2014-10-15T101351",
             },
         ]
 
@@ -168,7 +168,7 @@ class InlineAnalyticsTest(ModuleStoreTestCase):
                 "answer_value_text": "Option 1",
                 "answer_value_numeric": "null",
                 "variant": None,
-                "created": "2014-10-15T10:13:51",
+                "created": "2014-10-15T101351",
             },
         ]
 
@@ -218,7 +218,7 @@ class InlineAnalyticsTest(ModuleStoreTestCase):
                 "answer_value_text": "Option 1",
                 "answer_value_numeric": "null",
                 "variant": "123",
-                "created": "2014-10-15T10:13:51",
+                "created": "2014-10-15T101351",
             },
             {
                 "course_id": "A/B/C",
@@ -230,7 +230,7 @@ class InlineAnalyticsTest(ModuleStoreTestCase):
                 "answer_value_text": "Option 2",
                 "answer_value_numeric": "null",
                 "variant": None,
-                "created": "2014-10-15T10:13:51",
+                "created": "2014-10-15T101351",
             },
         ]
 
@@ -281,7 +281,7 @@ class InlineAnalyticsTest(ModuleStoreTestCase):
                 "answer_value_text": "Option 1",
                 "answer_value_numeric": "null",
                 "variant": "123",
-                "created": "2014-10-15T10:13:51",
+                "created": "2014-10-15T101351",
             },
             {
                 "course_id": "A/B/C",
@@ -293,7 +293,7 @@ class InlineAnalyticsTest(ModuleStoreTestCase):
                 "answer_value_text": "Option 2",
                 "answer_value_numeric": "null",
                 "variant": None,
-                "created": "2014-10-15T10:13:51",
+                "created": "2014-10-15T101351",
             },
         ]
 
@@ -332,7 +332,7 @@ class InlineAnalyticsTest(ModuleStoreTestCase):
                 "answer_value_text": "Option 1",
                 "answer_value_numeric": "null",
                 "variant": "123",
-                "created": "2014-10-15T10:13:51",
+                "created": "2014-10-15T101351",
             },
             {
                 "course_id": "A/B/C",
@@ -344,7 +344,7 @@ class InlineAnalyticsTest(ModuleStoreTestCase):
                 "answer_value_text": "Option 2",
                 "answer_value_numeric": "null",
                 "variant": None,
-                "created": "2014-10-15T10:13:51",
+                "created": "2014-10-15T101351",
             },
         ]
 

--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -1261,7 +1261,7 @@ def process_analytics_answer_dist(data, question_types_by_part, num_options_by_p
 
     # Determine the last updated date, convert to client TZ and format
     created_date = data[0]['created']
-    obj_date = datetime.strptime(created_date, '%Y-%m-%dT%H:%M:%S')
+    obj_date = datetime.strptime(created_date, '%Y-%m-%dT%H%M%S')
     obj_date = timezone('UTC').localize(obj_date)
     formatted_date_string = get_time_display(obj_date, None, coerce_tz=settings.TIME_ZONE_DISPLAYED_FOR_DEADLINES)
 


### PR DESCRIPTION
After upgrading the analytics api, in-line analytics stopped working.

This was caused by the date returned by the api changing
from:
 %Y-%m-%dT%H:%M:%S
to:
 %Y-%m-%dT%H%M%S