### PR TITLE
Add rename user feature to sysadmin page

### DIFF
--- a/lms/templates/sysadmin_dashboard.html
+++ b/lms/templates/sysadmin_dashboard.html
@@ -91,6 +91,24 @@ textarea {
     </div>
 
 	<hr />
+	<ul class="list-input">
+	  <li class="field text">
+	    <label for="username_old">${_('Old Username')}</label>
+	    <input type="text" name="username_old" size=40 />
+	  </li>
+	  <li class="field text">
+	    <label for="username_new">${_('New Username')}</label>
+	    <input type="text" name="username_new" size=40 />
+	  </li>
+	</ul>
+
+	<div class="form-actions">
+	  <p>
+	    <button type="submit" name="action" value="rename_user">${_('Rename user')}</button>
+	  </p>
+	</div>
+
+	<hr />
     <p>
       <button type="submit" name="action" value="download_users" style="width: 350px;">
 		${_('Download list of all users (csv file)')}


### PR DESCRIPTION
Currently, the ability to update/sync usernames is limited to the
manage.py rename_user command line tool. It was requested for this
feature to be available in the sysadmin dashboard.

This commit adds a user interface from which users can be renamed
from the system administrator dashboard. The interface can be found on
the `Users` tab of the sysadmin page.

A test has been added to the test_sysadmin.py test suite, and can be run
using the following command:
python ./manage.py lms test --verbosity=1 lms/djangoapps/dashboard/tests/test_sysadmin.py:TestSysadmin.test_rename_user --traceback --settings=test