### PR TITLE
Graphing Course Forums Data

### DIFF
--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -676,6 +676,7 @@ class TestInstructorAPIDenyLevels(ModuleStoreTestCase, LoginEnrollmentTestCase):
             ('get_ora2_responses', {}),
             ('get_course_forums_usage', {}),
             ('get_students_features', {}),
+            ('graph_course_forums_usage', {}),
         ]
         # Endpoints that only Instructors can access
         self.instructor_level_endpoints = [

--- a/lms/djangoapps/instructor/tests/test_tools.py
+++ b/lms/djangoapps/instructor/tests/test_tools.py
@@ -18,6 +18,7 @@ from xmodule.fields import Date
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory
 from opaque_keys.edx.keys import CourseKey
+import StringIO
 
 from ..views import tools
 
@@ -375,3 +376,54 @@ def msk_from_problem_urlname(course_id, urlname, block_type='problem'):
         urlname = urlname[:-4]
 
     return course_id.make_usage_key(block_type, urlname)
+
+
+class TestGenerateD3CourseForums(unittest.TestCase):
+    """
+    Tests generation of csv string for use in graphing course forums
+    """
+    def test_regular(self):
+        """
+        Test Generating d3 usable csvs
+        """
+        data_string = """ Date,Type,Number,Up Votes,Down Votes,Net Points
+2014-10-8,CommentThread,2,3,0,3
+2014-10-10,CommentThread,1,4,0,4
+2014-10-10,Response,1,3,0,3
+2014-10-11,CommentThread,1,0,0,0
+2014-10-11,Response,5,2,0,2
+2014-10-11,Comment,2,0,0,0
+2014-10-12,CommentThread,1,0,0,0
+2014-10-12,Response,1,0,0,0
+2014-10-12,Comment,1,0,0,0
+2014-10-13,CommentThread,16,5,0,5
+2014-10-13,Response,23,5,0,5
+2014-10-13,Comment,9,0,0,0
+2014-10-14,CommentThread,20,6,0,6
+2014-10-14,Response,51,4,0,4
+2014-10-14,Comment,17,0,0,0
+2014-10-15,CommentThread,18,1,0,1
+2014-10-15,Response,43,13,0,13
+2014-10-15,Comment,18,0,0,0
+2014-10-16,CommentThread,10,3,0,3 """
+        memfile = StringIO.StringIO(data_string)
+        output = tools.generate_course_forums_d3(memfile)
+        to_match = """Date,New Threads,Responses,Comments
+2014-10-8,2,0,0
+2014-10-10,1,1,0
+2014-10-11,1,5,2
+2014-10-12,1,1,1
+2014-10-13,16,23,9
+2014-10-14,20,51,17
+2014-10-15,18,43,18
+2014-10-16,10,0,0"""
+        self.assertEquals(output, to_match)
+
+    def test_no_data(self):
+        """
+        Test Generating d3 usable csvs
+        """
+        data_string = "Date,Type,Number,Up Votes,Down Votes,Net Points"
+        memfile = StringIO.StringIO(data_string)
+        output = tools.generate_course_forums_d3(memfile)
+        self.assertIsNone(output)

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -137,4 +137,8 @@ urlpatterns = patterns('',  # nopep8
     # Collect course forums data
     url(r'get_course_forums_usage',
         'instructor.views.api.get_course_forums_usage', name="get_course_forums_usage"),
+
+    # Generating course forums usage graph
+    url(r'^graph_course_forums_usage',
+        'instructor.views.api.graph_course_forums_usage', name="graph_course_forums_usage"),
 )

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -332,6 +332,8 @@ def _section_data_download(course, access):
         'get_student_forums_usage_url': reverse('get_student_forums_usage', kwargs={'course_id': unicode(course_key)}),
         'get_ora2_responses_url': reverse('get_ora2_responses', kwargs={'course_id': course_key.to_deprecated_string()}),
         'get_course_forums_usage_url': reverse('get_course_forums_usage', kwargs={'course_id': course_key.to_deprecated_string()}),
+        'graph_course_forums_usage_url': reverse('graph_course_forums_usage',
+                                                 kwargs={'course_id': unicode(course_key)}),
     }
     return section_data
 

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -1165,6 +1165,13 @@ section.instructor-dashboard-content-2 {
       }
     }
 
+    .graph-forums{
+      cursor: pointer;
+      float:right;
+      padding-left: 25px;
+      padding-right: 10px;
+    }
+
     .delete-report{
       float: right;
       margin-right: 10px;
@@ -1177,8 +1184,37 @@ section.instructor-dashboard-content-2 {
       text-decoration: none;
     }
 
+
   }
 
+  .report-downloads-graph-block{
+    width:100%;
+  }
+  .report-downloads-graph-title{
+    text-align:center;
+    margin: 0 auto;
+  }
+
+  .report-downloads-graph{
+    width:100%;
+    margin-left: auto ;
+    margin-right: auto ;
+    font: 10px sans-serif;
+    .axis path,
+    .axis line {
+      fill: none;
+      stroke: #000;
+      shape-rendering: crispEdges;
+    }
+
+    .bar {
+      fill: steelblue;
+    }
+
+    .x.axis path {
+      display: none;
+    }
+  }
 }
 
 // view - metrics

--- a/lms/templates/class_dashboard/d3_graph_data_download.js
+++ b/lms/templates/class_dashboard/d3_graph_data_download.js
@@ -1,0 +1,113 @@
+/*
+Parameters:
+(1) csvstring
+    A newline joined, comma separated datapoints. It must have a header and one of the columns must be named 'Date'
+   example: "Date,New Threads,Responses,Comments\n2014-10-10,2,0,0\n2014-10-11,1,1,0\n2014-10-12,1,5,2It draws
+(2) className
+    Class of the html element to draw the svg in
+ */
+
+d3_graph_data_download = function(csvstring, className) {
+    data = d3.csv.parse(csvstring);
+    var margin = {top: 20, right: 80, bottom: 30, left: 50},
+        width = $('.report-downloads-graph').parent().width() - margin.left - margin.right;
+        height = 500 - margin.top - margin.bottom;
+    var parseDate = d3.time.format("%Y-%m-%d").parse;
+    var color = d3.scale.category10();
+    var barWidth =  (width-300)/data.length;
+    //leaving extra space to the right for the legend
+    var x = d3.time.scale()
+        .range([20, width-barWidth-70]);
+
+    var y = d3.scale.linear()
+        .rangeRound([height, 0]);
+
+    //these colors don't exactly correspond to the exact elements in the graph but to generate them
+    //we read the header to generate the colors
+    var header = d3.keys(data[0]);
+    var coloredHeader = header.map(color);
+
+    var color = d3.scale.ordinal()
+        .range(coloredHeader);
+
+    var xAxis = d3.svg.axis()
+        .scale(x)
+        .orient("bottom")
+        .ticks(Math.min(5, data.length));
+    var yAxis = d3.svg.axis()
+        .scale(y)
+        .orient("left")
+        .tickFormat(d3.format(".2s"));
+
+    //clear div in case there is another graph in it
+    $("."+className).html("");
+    var svg = d3.select(".report-downloads-graph").append("svg")
+        .attr("width", width + margin.left + margin.right)
+        .attr("height", height + margin.top + margin.bottom)
+        .append("g")
+        .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+    color.domain(d3.keys(data[0]).filter(function(key) { return key !== "Date"; }));
+
+    data.forEach(function(d) {
+        d.date = parseDate(d.Date);
+        var y0 = 0;
+        d.counts = color.domain().map(function(name) {
+            return {
+                name: name, y0: y0, y1: y0 += +d[name]}; });
+        d.total = d.counts[d.counts.length - 1].y1;
+    });
+
+    x.domain(d3.extent(data, function(d) { return d.date; }));
+    y.domain([0, d3.max(data, function(d) { return d.total; })]);
+
+    svg.append("g")
+        .attr("class", "x axis")
+        .attr("transform", "translate("+  barWidth/2 +"," +height + ")")
+        .call(xAxis);
+    svg.append("g")
+        .attr("class", "y axis")
+        .call(yAxis)
+        .append("text")
+        .attr("transform", "rotate(-90)")
+        .attr("y", 6)
+        .attr("dy", ".71em")
+        .style("text-anchor", "end")
+        .text("Count");
+
+    var state = svg.selectAll(".state")
+        .data(data)
+        .enter().append("g")
+        .attr("class", "g")
+        .attr("transform", function(d) {
+            var st = "translate(" + x(d.date) + ",0)";
+            return st;
+        });
+
+    state.selectAll("rect")
+        .data(function(d) { return d.counts; })
+        .enter().append("rect")
+        .attr("width", barWidth)
+        .attr("y", function(d) { return y(d.y1); })
+        .attr("height", function(d) { return y(d.y0) - y(d.y1); })
+        .style("fill", function(d) { return color(d.name); });
+
+    var legend = svg.selectAll(".legend")
+        .data(color.domain().slice().reverse())
+        .enter().append("g")
+        .attr("class", "legend")
+        .attr("transform", function(d, i) { return "translate(0," + i * 20 + ")"; });
+
+    legend.append("rect")
+        .attr("x", width )
+        .attr("width", 18)
+        .attr("height", 18)
+        .style("fill", color);
+
+    legend.append("text")
+        .attr("x", width-5)
+        .attr("y", 9)
+        .attr("dy", ".35em")
+        .style("text-anchor", "end")
+        .text(function(d) { return d; });
+
+};

--- a/lms/templates/instructor/instructor_dashboard_2/data_download.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download.html
@@ -1,6 +1,12 @@
 <%! from django.utils.translation import ugettext as _ %>
 <%page args="section_data"/>
 
+<script>
+  ${d3_graph_data_download.body()}
+</script>
+
+<%namespace name="d3_graph_data_download" file="/class_dashboard/d3_graph_data_download.js"/>
+
 
 <div class="data-download-container action-type-container">
   <h2>${_("Data Download")}</h2>
@@ -66,9 +72,15 @@
 
     ## Translators: a table of URL links to report files appears after this sentence.
     <p>${_("<b>Note</b>: To keep student data secure, you cannot save or email these links for direct access. Copies of links expire within 5 minutes.")}</p><br>
+
     <div class="report-downloads-table" id="report-downloads-table" data-endpoint="${ section_data['list_report_downloads_url'] }" ></div>
-    <div class="report-downloads-delete" data-endpoint="${ section_data['delete_report_download_url'] }" ></div>
+    <div class="report-downloads-action-block">
+        <div class="report-downloads-graph-title"></div>
+        <div class="report-downloads-graph" id="report-downloads-graph" data-endpoint="${ section_data['graph_course_forums_usage_url'] }"></div>
+        <div class="report-downloads-delete" data-endpoint="${ section_data['delete_report_download_url'] }" ></div>   
+   </div>
   </div>
+
 %endif
 
 %if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):


### PR DESCRIPTION
When a user retrieves the file for a course forums usage data download, they may graph it.
tagging @caesar2164 @dcadams 

Ready for final review. 

Finalized button placement:
![screen shot 2015-03-28 at 3 07 53 pm](https://cloud.githubusercontent.com/assets/461386/6883191/5b5fe562-d55f-11e4-8757-b602899e845a.png)



Older screenshots (graphs are relevant, download links are not)
![screen shot 2015-03-06 at 4 53 32 pm](https://cloud.githubusercontent.com/assets/461386/6539345/adf40ffa-c426-11e4-8a20-f2c77347bcd3.png)
![screen shot 2015-03-06 at 4 53 28 pm](https://cloud.githubusercontent.com/assets/461386/6539346/adf6ccfe-c426-11e4-854e-3503402aa567.png)
![screen shot 2015-03-18 at 2 02 43 pm]
