### PR TITLE
Allow bulk email to queries

### DIFF
--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -867,11 +867,13 @@ def save_query(request, course_id):
         for query in existing_queries
         if (query != "working" and query != "")
     ]
-    success = data_access.save_query(course_id, clean_existing)
+    group = data_access.save_query(course_id, clean_existing)
+    group_title = group.title or u'Query saved at ' + group.created.strftime("%m-%d-%y %H:%M")
 
     response_payload = {
         'course_id': course_id.to_deprecated_string(),
-        'success': success,
+        'group_id': group.id,
+        'group_title': group_title,
     }
     return JsonResponse(response_payload)
 

--- a/lms/djangoapps/instructor/views/data_access.py
+++ b/lms/djangoapps/instructor/views/data_access.py
@@ -83,7 +83,7 @@ def save_query(course_id, queries):
         perm_query.save()
         relation = SubqueryForGroupedQuery(grouped=group, query=perm_query)
         relation.save()
-    return True
+    return group
 
 
 def get_group_query_students(course_id, group_id):

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -34,7 +34,9 @@ from student.models import CourseEnrollment
 from shoppingcart.models import Coupon, PaidCourseRegistration
 from course_modes.models import CourseMode, CourseModesArchive
 from student.roles import CourseFinanceAdminRole
+from instructor_email_widget.models import GroupedQuery
 
+from bulk_email.models import CourseEmail
 from class_dashboard.dashboard_data import get_section_display_name, get_array_section_has_problem
 from .tools import get_units_with_due_date, title_or_url, bulk_email_is_enabled_for_course
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
@@ -338,6 +340,11 @@ def _section_data_download(course, access):
 def _section_send_email(course, access):
     """ Provide data for the corresponding bulk email section """
     course_key = course.id
+    queries = GroupedQuery.objects.filter(course_id=course_key)
+    query_options = tuple(
+        (query.id, query.title or u'Query saved at ' + query.created.strftime("%m-%d-%y %H:%M"))
+        for query in queries
+    )
 
     # This HtmlDescriptor is only being used to generate a nice text editor.
     html_module = HtmlDescriptor(
@@ -360,6 +367,7 @@ def _section_send_email(course, access):
         'section_display_name': _('Email'),
         'keywords_supported': [{'name':keyword, 'desc': value.desc} for keyword, value in keyword_substitution.KEYWORD_FUNCTION_MAP.iteritems()],
         'access': access,
+        'to_options': CourseEmail.TO_OPTION_CHOICES + query_options,
         'send_email': reverse('send_email', kwargs={'course_id': course_key.to_deprecated_string()}),
         'editor': email_editor,
         'list_instructor_tasks_url': reverse(

--- a/lms/djangoapps/instructor_task/subtasks.py
+++ b/lms/djangoapps/instructor_task/subtasks.py
@@ -296,6 +296,19 @@ def queue_subtasks_for_query(entry, action_name, create_subtask_fcn, item_querys
     task_id = entry.task_id
     total_num_items = item_queryset.count()
 
+    if total_num_items == 0:
+        TASK_LOG.info("Task %s: 0 items to process, no subtasks to queue", task_id)
+        return {
+            'action_name': action_name,
+            'attempted': 0,
+            'failed': 0,
+            'skipped': 0,
+            'succeeded': 0,
+            'total': total_num_items,
+            'duration_ms': 0,
+            'start_time': time(),
+        }
+
     # Calculate the number of tasks that will be created, and create a list of ids for each task.
     total_num_subtasks = _get_number_of_subtasks(total_num_items, items_per_task)
     subtask_id_list = [str(uuid4()) for _ in range(total_num_subtasks)]

--- a/lms/static/coffee/src/instructor_dashboard/membership.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/membership.coffee
@@ -1031,6 +1031,7 @@ class EmailWidget
       curRow.remove()
       queryToDelete = curRow.getAttribute('groupquery')
       @delete_saved_query(queryToDelete)
+      $('#send_email option[value="' + queryToDelete + '"]').remove()
     $td = $('<td>')
     $td.append($deleteBtn)
     row.appendChild($td[0])
@@ -1196,9 +1197,11 @@ class EmailWidget
 
   # save queries in active queries
   send_save_query: ->
-    @save_query (error, students) =>
+    @save_query (error, data) =>
       if error
         return @show_errors error
+
+      $('#send_email select').append('<option value="' + data['group_id'] + '">' + data['group_title'] + '</option>')
       @load_saved_queries()
 
   get_estimated: (cb)->

--- a/lms/static/coffee/src/instructor_dashboard/send_email.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/send_email.coffee
@@ -53,17 +53,19 @@ class SendEmail
           return
 
         success_message = gettext("Your email was successfully queued for sending.")
-        send_to = @$send_to.val().toLowerCase()
+        send_to = @$send_to.val()
         if send_to == "myself"
           confirm_message = gettext("You are about to send an email titled '<%= subject %>' to yourself. Is this OK?")
         else if send_to == "staff"
           confirm_message = gettext("You are about to send an email titled '<%= subject %>' to everyone who is staff or instructor on this course. Is this OK?")
-        else
+        else if send_to == "all"
           confirm_message = gettext("You are about to send an email titled '<%= subject %>' to ALL (everyone who is enrolled in this course as student, staff, or instructor). Is this OK?")
           success_message = gettext("Your email was successfully queued for sending. Please note that for large classes, it may take up to an hour (or more, if other courses are simultaneously sending email) to send all emails.")
+        else
+          confirm_message = gettext("You are about to send an email titled '<%= subject %>' to <%= to_option %>. Is this OK?")
 
         subject = @$subject.val()
-        full_confirm_message = _.template(confirm_message, {subject: subject})
+        full_confirm_message = _.template(confirm_message, {subject: subject, to_option: @$send_to.find(':selected').text().toLowerCase()})
 
         if confirm full_confirm_message
 

--- a/lms/templates/instructor/instructor_dashboard_2/send_email.html
+++ b/lms/templates/instructor/instructor_dashboard_2/send_email.html
@@ -9,17 +9,9 @@
     <li class="field">
       <label for="id_to">${_("Send to:")}</label><br/>
       <select id="id_to" name="send_to">
-        <option value="myself">${_("Myself")}</option>
-        %if to_option == "staff":
-        <option value="staff" selected="selected">${_("Staff and instructors")}</option>
-        %else:
-        <option value="staff">${_("Staff and instructors")}</option>
-          %endif
-          %if to_option == "all":
-            <option value="all" selected="selected">${_("All (students, staff and instructors)")}</option>
-          %else:
-      <option value="all">${_("All (students, staff and instructors)")}</option>
-      %endif
+      % for to_option in section_data['to_options']:
+        <option value="${to_option[0]}">${_(to_option[1])}</option>
+      % endfor
       </select>
     </li>
   <br/>


### PR DESCRIPTION
Queries saved in the Membership tab can be selected
as the recipient for bulk emails. Queries are executed
at the time of sending the email.

@caijim @stvstnfrd @caesar2164 