### PR TITLE
Bugfix for overcounting forums responses

### DIFF
--- a/lms/djangoapps/instructor/utils.py
+++ b/lms/djangoapps/instructor/utils.py
@@ -159,7 +159,7 @@ def generate_course_forums_query(course_id, query_type, parent_id_check=None):
         {'$sort': SON([('_id.year', 1), ('_id.month', 1), ('_id.day', 1)])},
     ]
     if query_type == 'Comment':
-        if parent_id_check:
+        if parent_id_check is not None:
             query[0]['$match']['parent_id'] = {'$exists': parent_id_check}
     return query
 


### PR DESCRIPTION
I want parent_id_check to be set as long as parent_id_check is not None. Because it's false sometimes, it didn't pass the conditional. Explicitly checking for None 

@stvstnfrd 