### PR TITLE
Feature for enabling instructors to rename saved queries in email widget

### DIFF
--- a/lms/djangoapps/bulk_email/tests/test_email.py
+++ b/lms/djangoapps/bulk_email/tests/test_email.py
@@ -272,7 +272,7 @@ class TestEmailSendFromDashboard(ModuleStoreTestCase):
         save_args = {
             'existing': ','.join(existing),
         }
-        response = self.client.get(save_url, save_args)
+        response = self.client.post(save_url, save_args)
         return response
 
     def _get_saved_queries(self):

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -853,12 +853,12 @@ def delete_saved_query(request, course_id, query_to_delete):  # pylint: disable=
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
 @require_level('staff')
-@require_query_params(existing="Ids of previously issued queries")
 def save_query(request, course_id):
     """
     Saves a group of queries and assigns them the same group ID
     """
-    existing = request.GET.get('existing')
+    existing = request.POST.get('existing')
+    saved_name = request.POST.get('savedName')
     existing_queries = existing.split(',')
     if len(existing) == 0:
         return JsonResponse({
@@ -870,7 +870,8 @@ def save_query(request, course_id):
         for query in existing_queries
         if (query != "working" and query != "")
     ]
-    group = data_access.save_query(course_id, clean_existing)
+
+    group = data_access.save_query(course_id, saved_name, clean_existing)
     group_title = group.title or u'Query saved at ' + group.created.strftime("%m-%d-%y %H:%M")
 
     response_payload = {
@@ -926,6 +927,11 @@ def get_saved_queries(request, course_id):  # pylint: disable=unused-argument
         relation.query_id: relation.grouped_id
         for relation in relations
     }
+
+    title_map = {
+        group.id: group.title
+        for group in groups
+    }
     for relation in relations:
         relation_map[relation.query_id] = relation.grouped_id
     for group in groups:
@@ -942,6 +948,7 @@ def get_saved_queries(request, course_id):  # pylint: disable=unused-argument
                 'type': query.query_type,
                 'group': group_id,
                 'created': created[group_id],
+                'group_title': title_map[group_id],
             })
     response_payload = {
         'course_id': course_id.to_deprecated_string(),
@@ -1111,6 +1118,33 @@ def list_course_problems(request, course_id):
         'course_id': course_id.to_deprecated_string(),
         'data': problem_list,
         'success': True,
+    }
+    return JsonResponse(response_payload)
+
+
+@ensure_csrf_cookie
+@cache_control(no_cache=True, no_store=True, must_revalidate=True)
+@require_level('staff')
+def save_group_name(request, course_id):
+    """
+    Required POST params:
+         group_id : id of the saved group query to rename
+         group_name: the new name of the group query with id group_id
+    """
+    group_id = request.POST.get('group_id')
+    group_name = request.POST.get('group_name')
+
+    if group_id is None or group_name is None:
+        return JsonResponse({
+            'course_id': unicode(course_id),
+            'success': False,
+        })
+
+    success = data_access.save_group_name(group_id, group_name)
+
+    response_payload = {
+        'course_id': unicode(course_id),
+        'success': success,
     }
     return JsonResponse(response_payload)
 

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -48,6 +48,8 @@ urlpatterns = patterns('',  # nopep8
     # the parameter-less url is here as a convenience because we don't know the params at the time of calling 'reverse
     url(r'^delete_temp_query',
         'instructor.views.api.delete_temp_query', name="delete_temp_query"),
+    url(r'^save_group_name',
+        'instructor.views.api.save_group_name', name="save_group_name"),
     url(r'^get_students_features(?P<csv>/csv)?$',
         'instructor.views.api.get_students_features', name="get_students_features"),
     url(r'^get_purchase_transaction(?P<csv>/csv)?$',

--- a/lms/djangoapps/instructor/views/data_access.py
+++ b/lms/djangoapps/instructor/views/data_access.py
@@ -64,12 +64,15 @@ def delete_group_temp_queries_and_students(group_id):
     old_queries.delete()
     subqueries.delete()
 
-def save_query(course_id, queries):
+
+def save_query(course_id, saved_name, queries):
     """
     Makes a new grouped query by saving the individual subqueries and then associating them to a grouped query
     """
+    if saved_name is None:
+        saved_name = ""
     temp_queries = TemporaryQuery.objects.filter(id__in=queries)
-    group = GroupedQuery(course_id=course_id, title="")
+    group = GroupedQuery(course_id=course_id, title=saved_name)
     group.save()
     for temp_query in temp_queries:
         perm_query = SavedQuery(
@@ -84,6 +87,16 @@ def save_query(course_id, queries):
         relation = SubqueryForGroupedQuery(grouped=group, query=perm_query)
         relation.save()
     return group
+
+
+def save_group_name(group_id, group_name):
+    """
+    Assigns group_name to an already-saved group with id = group_id
+    """
+    group = GroupedQuery.objects.get(id=group_id)
+    group.title = group_name
+    group.save()
+    return True
 
 
 def get_group_query_students(course_id, group_id):

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -263,6 +263,7 @@ def _section_membership(course, access):
         'get_single_query': reverse('get_single_query', kwargs={'course_id': course_key.to_deprecated_string()}),
         'save_query': reverse('save_query', kwargs={'course_id': course_key.to_deprecated_string()}),
         'get_saved_queries': reverse('get_saved_queries', kwargs={'course_id': course_key.to_deprecated_string()}),
+        'save_group_name': reverse('save_group_name', kwargs={'course_id': course_key.to_deprecated_string()}),
         'get_temp_queries': reverse('get_temp_queries', kwargs={'course_id': course_key.to_deprecated_string()}),
         "delete_saved_query": reverse("delete_saved_query", kwargs={'course_id': course_key.to_deprecated_string()}),
         "delete_temp_query": reverse("delete_temp_query", kwargs={'course_id': course_key.to_deprecated_string()}),

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -1009,6 +1009,35 @@ section.instructor-dashboard-content-2 {
       color: $black
     }
 
+    .emailWidget.invisibleSavedGroupName {
+      display:none;
+    }
+
+    .emailWidget.saveEditName, .emailWidget.cancelEditName {
+      display:inline-block;
+    }
+
+    .emailWidget.cancelEditName {
+      float:right;
+    }
+
+    .emailWidget.saveEditName {
+      float:left;
+    }
+
+    .emailWidget.editNameInput {
+      width:100%;
+    }
+
+    .emailWidget.editName, .emailWidget.saveEditName, .emailWidget.cancelEditName{
+      color: $black;
+      cursor: pointer;
+      text-align: right;
+      &:hover, &:focus {
+        color: $blue;
+      }
+    }
+
 
     .loadQuery {
       color: $black;
@@ -1064,6 +1093,13 @@ section.instructor-dashboard-content-2 {
       border: 1px solid $light-gray;
       background-color: #efefef;
       box-shadow: inset #bbb 0 1px 1px 0;
+    }
+
+    .savequeryname{
+      float: right;
+      right: $baseline;
+      font-size: 15px;
+      margin-right: 5px;
     }
 
     .savequery {

--- a/lms/templates/instructor/instructor_dashboard_2/membership.html
+++ b/lms/templates/instructor/instructor_dashboard_2/membership.html
@@ -339,6 +339,7 @@
       <div class="bottom-email">
           <input type="button" name="getcsv" class="emailWidget getcsv" value="${_("Get CSV")}" data-endpoint="${ section_data['get_all_students'] }" data-csv="true" class="disabled">
           <input type="button" name="savequery" class="emailWidget savequery" value="${_("Save Query")}" data-endpoint="${ section_data['save_query'] }" data-csv="true" class="disabled">
+          <input type="text" name="savequeryname" class="emailWidget savequeryname" placeholder="Saved Query Name"><br>
           <div class="emailWidget estimated">${_("Approx 0 students selected")}</div>
           <input type="button" name="getest" class="emailWidget getest" value="${_("Update Students Estimate")}" data-endpoint="${ section_data['get_all_students'] }" >
           <input type="button" name="startover" class="emailWidget startover" value="${_("Clear Active Queries")}">
@@ -348,12 +349,15 @@
         <thead>
           <tr>
               <td class="label">${_("Date Saved")}</td>
-              <td class="label">${_("Query")}</td>
+              <td class="label">${_("Query Name")}</td>
               <td class="label"></td>
               <td class="label"></td>
           </tr>
         </thead>
-        <tbody class="emailWidget savedQueriesTable" data-endpoint="${ section_data['get_saved_queries'] }"></tbody>
+        <tbody class="emailWidget savedQueriesTable"
+               data-endpoint="${ section_data['get_saved_queries'] }"
+               data-group-name-endpoint="${ section_data['save_group_name'] }"
+                ></tbody>
 
       </table>
         <table>


### PR DESCRIPTION
Feature for enabling instructors to rename saved queries in email widget.

![groupname](https://cloud.githubusercontent.com/assets/461386/6883478/c182fc92-d56b-11e4-9d54-64ed1916c744.gif)

![emailsync](https://cloud.githubusercontent.com/assets/461386/6954005/63636baa-d882-11e4-9a14-1f21ff54b172.gif)


@kluo 