### PR TITLE
Chronologically reorder downloaded reports and add Delete Report feature

### DIFF
--- a/lms/djangoapps/instructor/tests/test_api.py
+++ b/lms/djangoapps/instructor/tests/test_api.py
@@ -2475,6 +2475,15 @@ class TestInstructorAPILevelsDataDump(ModuleStoreTestCase, LoginEnrollmentTestCa
         res_json = json.loads(response.content)
         self.assertEqual(res_json, expected_response)
 
+    def test_delete_report_download(self):
+        def noop():
+            """method to be used as a side_effect for LocalFSReportStore.delete_file"""
+            pass
+        url = reverse('delete_report_download', kwargs={'course_id': unicode(self.course.id)})
+        with patch('instructor_task.models.LocalFSReportStore.delete_file', side_effect=noop()):
+            response = self.client.post(url, {})
+        self.assertEqual(response.status_code, 200)
+
     @ddt.data(*REPORTS_DATA)
     @ddt.unpack
     def test_calculate_report_csv_success(self, report_type, instructor_api_endpoint, task_api_endpoint, extra_instructor_api_kwargs):

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -2067,6 +2067,23 @@ def list_forum_members(request, course_id):
 @ensure_csrf_cookie
 @cache_control(no_cache=True, no_store=True, must_revalidate=True)
 @require_level('staff')
+def delete_report_download(request, course_id):
+    """
+    Deletes a downloaded report that was previously generated from the Instructor Dashboard
+    """
+    course_id = SlashSeparatedCourseKey.from_string(course_id)
+    filename = request.POST.get('filename')
+    report_store = ReportStore.from_config()
+    report_store.delete_file(course_id, filename)
+    message = {
+        'status': _('The report was successfully deleted!'),
+    }
+    return JsonResponse(message)
+
+
+@ensure_csrf_cookie
+@cache_control(no_cache=True, no_store=True, must_revalidate=True)
+@require_level('staff')
 def get_student_forums_usage(request, course_id):
     """
     Pushes a Celery task which will aggregate student forums usage statistics for a course into a .csv

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -126,6 +126,10 @@ urlpatterns = patterns('',  # nopep8
     url(r'get_student_forums_usage',
         'instructor.views.api.get_student_forums_usage', name='get_student_forums_usage'),
 
+    # Delete Report Download
+    url(r'delete_report_download',
+        'instructor.views.api.delete_report_download', name='delete_report_download'),
+
     # Collect ora2 data
     url(r'get_ora2_responses',
         'instructor.views.api.get_ora2_responses', name="get_ora2_responses"),

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -323,6 +323,7 @@ def _section_data_download(course, access):
         'access': access,
         'get_grading_config_url': reverse('get_grading_config', kwargs={'course_id': course_key.to_deprecated_string()}),
         'get_students_features_url': reverse('get_students_features', kwargs={'course_id': course_key.to_deprecated_string()}),
+        'delete_report_download_url': reverse('delete_report_download', kwargs={'course_id': unicode(course_key)}),
         'get_anon_ids_url': reverse('get_anon_ids', kwargs={'course_id': course_key.to_deprecated_string()}),
         'list_instructor_tasks_url': reverse('list_instructor_tasks', kwargs={'course_id': course_key.to_deprecated_string()}),
         'list_report_downloads_url': reverse('list_report_downloads', kwargs={'course_id': course_key.to_deprecated_string()}),

--- a/lms/djangoapps/instructor_task/models.py
+++ b/lms/djangoapps/instructor_task/models.py
@@ -327,13 +327,18 @@ class S3ReportStore(ReportStore):
         can be plugged straight into an href
         """
         course_dir = self.key_for(course_id, '')
-        return sorted(
+        sorted_link_data = sorted(
             [
-                (key.key.split("/")[-1], key.generate_url(expires_in=300))
+                # each element in the array is a list with the following format: ('date, 'filename', 'url')
+                (key.key.split('/')[-1].split('_')[-1].split('.csv')[0], key.key.split('/')[-1], key.generate_url(expires_in=300))
                 for key in self.bucket.list(prefix=course_dir.key)
             ],
             reverse=True
         )
+        return [
+            (link_data[1], link_data[2])
+            for link_data in sorted_link_data
+        ]
 
 
 class LocalFSReportStore(ReportStore):
@@ -410,10 +415,15 @@ class LocalFSReportStore(ReportStore):
         course_dir = self.path_to(course_id, '')
         if not os.path.exists(course_dir):
             return []
-        return sorted(
+        sorted_link_data = sorted(
             [
-                (filename, ("file://" + urllib.quote(os.path.join(course_dir, filename))))
+                # each element in the array is a list with the following format: ('date, 'filename', 'url')
+                (filename.split('_')[-1].split('.csv')[0], filename, ('file://' + urllib.quote(os.path.join(course_dir, filename))))
                 for filename in os.listdir(course_dir)
             ],
             reverse=True
         )
+        return [
+            (link_data[1], link_data[2])
+            for link_data in sorted_link_data
+        ]

--- a/lms/djangoapps/instructor_task/models.py
+++ b/lms/djangoapps/instructor_task/models.py
@@ -321,6 +321,13 @@ class S3ReportStore(ReportStore):
 
         self.store(course_id, filename, output_buffer)
 
+    def delete_file(self, course_id, filename):
+        """
+        Given the `course_id` and `filename` for the report, this method deletes the report
+        """
+        key = self.key_for(course_id, filename)
+        self.bucket.delete_key(key)
+
     def links_for(self, course_id):
         """
         For a given `course_id`, return a list of `(filename, url)` tuples. `url`
@@ -403,6 +410,13 @@ class LocalFSReportStore(ReportStore):
         csvwriter.writerows(self._get_utf8_encoded_rows(rows))
 
         self.store(course_id, filename, output_buffer)
+
+    def delete_file(self, course_id, filename):
+        """
+        Given the `course_id` and `filename` for the report, this method deletes the report
+        """
+        path = self.path_to(course_id, filename)
+        os.remove(path)
 
     def links_for(self, course_id):
         """

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -93,6 +93,23 @@ class TestReportStore(TestReportMixin, InstructorTaskCourseTestCase):
     def setUp(self):
         self.course = CourseFactory.create()
 
+    def test_delete_report(self):
+        report_store = ReportStore.from_config()
+        task_input = {'features': []}
+
+        links = report_store.links_for(self.course.id)
+        self.assertEquals(len(links), 0)
+        with patch('instructor_task.tasks_helper._get_current_task'):
+            upload_students_csv(None, None, self.course.id, task_input, 'calculated')
+        links = report_store.links_for(self.course.id)
+        self.assertEquals(len(links), 1)
+
+        filename = links[0][0]
+        report_store.delete_file(self.course.id, filename)
+
+        links = report_store.links_for(self.course.id)
+        self.assertEquals(len(links), 0)
+
     def test_reports_rev_chronologically_sorted(self):
         report_store = ReportStore.from_config()
         test_rows = [['row1_field1', 'row1_field2', 'row1_field3'], ['row2_field1', 'row2_field2', 'row2_field3']]

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -87,6 +87,37 @@ class TestInstructorGradeReport(TestReportMixin, InstructorTaskCourseTestCase):
 
 
 @ddt.ddt
+class TestReportStore(TestReportMixin, InstructorTaskCourseTestCase):
+    """Tests for the ReportStore model"""
+
+    def setUp(self):
+        self.course = CourseFactory.create()
+
+    def test_reports_rev_chronologically_sorted(self):
+        report_store = ReportStore.from_config()
+        test_rows = [['row1_field1', 'row1_field2', 'row1_field3'], ['row2_field1', 'row2_field2', 'row2_field3']]
+        rev_chronological_filenames = [
+            'filename4_2015-03-10-0024.csv',
+            'filename3_2015-03-10-0023.csv',
+            'filename2_2015-03-10-0022.csv',
+            'filename1_2015-03-10-0021.csv',
+        ]
+
+        links = report_store.links_for(self.course.id)
+        self.assertEquals(len(links), 0)
+
+        report_store.store_rows(self.course.id, rev_chronological_filenames[1], test_rows)
+        report_store.store_rows(self.course.id, rev_chronological_filenames[3], test_rows)
+        report_store.store_rows(self.course.id, rev_chronological_filenames[0], test_rows)
+        report_store.store_rows(self.course.id, rev_chronological_filenames[2], test_rows)
+
+        links = report_store.links_for(self.course.id)
+        self.assertEquals(len(links), 4)
+        filenames = [link[0] for link in links]
+        self.assertEquals(filenames, rev_chronological_filenames)
+
+
+@ddt.ddt
 class TestStudentReport(TestReportMixin, InstructorTaskCourseTestCase):
     """
     Tests that CSV student profile report generation works.

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -1164,7 +1164,21 @@ section.instructor-dashboard-content-2 {
         overflow-x: hidden !important;
       }
     }
+
+    .delete-report{
+      float: right;
+      margin-right: 10px;
+      text-decoration: underline;
+      color: $blue;
+    }
+
+    .delete-report:hover{
+      cursor: pointer;
+      text-decoration: none;
+    }
+
   }
+
 }
 
 // view - metrics

--- a/lms/templates/instructor/instructor_dashboard_2/data_download.html
+++ b/lms/templates/instructor/instructor_dashboard_2/data_download.html
@@ -66,8 +66,8 @@
 
     ## Translators: a table of URL links to report files appears after this sentence.
     <p>${_("<b>Note</b>: To keep student data secure, you cannot save or email these links for direct access. Copies of links expire within 5 minutes.")}</p><br>
-
     <div class="report-downloads-table" id="report-downloads-table" data-endpoint="${ section_data['list_report_downloads_url'] }" ></div>
+    <div class="report-downloads-delete" data-endpoint="${ section_data['delete_report_download_url'] }" ></div>
   </div>
 %endif
 


### PR DESCRIPTION

In order for instructors to be able to easily keep track of the reports
they have generated, this commit chronologically orders the reports that
are available for download on the bottom of the instructor dashboard
(most recent on the top). This commit also adds a 'Delete Report' feature,
which allows instructors to delete a report from the Data Download page
of the instructor's dashboard. A test suite for this commit has been
written and can be run as follows:

python ./manage.py lms test --verbosity=1
lms/djangoapps/instructor_task/tests/test_tasks_helper.py:TestReportStore
--traceback --settings=test

python ./manage.py lms test --verbosity=1
lms/djangoapps/instructor/tests/test_api.py:TestInstructorAPILevelsDataDump.test_delete_report_download
--traceback --settings=test

![del_report_pic](https://cloud.githubusercontent.com/assets/1752973/6649178/c5294c64-c9a1-11e4-9786-045e4c1e3626.gif)

