### PR TITLE
Inline analytics first attempts

### DIFF
--- a/lms/djangoapps/courseware/inline_analytics_utils.py
+++ b/lms/djangoapps/courseware/inline_analytics_utils.py
@@ -30,7 +30,7 @@ def get_responses_data(block):
        - FormulaResponse
 
     Problems with randomize are not currently supported for in-line analytics.
-    If settings.ANALYTICS_ANSWER_DIST_URL is unset then returns None
+    If settings.ANALYTICS_DATA_URL is unset then returns None
     """
     responses_data = []
     valid_group_nodes = []

--- a/lms/djangoapps/courseware/module_render.py
+++ b/lms/djangoapps/courseware/module_render.py
@@ -485,7 +485,7 @@ def get_module_system_for_user(user, field_data_cache,
             block_wrappers.append(partial(add_staff_markup, user, has_instructor_access))
 
     # Add button for in-line analytics answer distribution
-    if getattr(settings, 'ANALYTICS_ANSWER_DIST_URL'):
+    if getattr(settings, 'ANALYTICS_DATA_URL'):
         if has_access(user, 'staff', descriptor, course_id):
             block_wrappers.append(partial(add_inline_analytics, user))
 

--- a/lms/djangoapps/courseware/tests/test_inline_analytics_integration.py
+++ b/lms/djangoapps/courseware/tests/test_inline_analytics_integration.py
@@ -35,8 +35,8 @@ class InlineAnalyticsTest(ModuleStoreTestCase):
         json_analytics_data = json.dumps(analytics_data)
         self.data = {"data": json_analytics_data}
 
-    @override_settings(ANALYTICS_DATA_URL='dummy_url')
-    @override_settings(ZENDESK_URL='https://stanfordonline.zendesk.com')
+    @override_settings(ANALYTICS_DATA_URL='dummy_url',
+                       ZENDESK_URL='https://stanfordonline.zendesk.com')
     def test_regular_user(self):
 
         request = self.factory.post('', self.data)
@@ -54,16 +54,13 @@ class InlineAnalyticsTest(ModuleStoreTestCase):
         response = get_analytics_answer_dist(request)
         self.assertEquals(response.content, 'A problem has occurred retrieving the data, to report the problem click <a href="https://stanfordonline.zendesk.com/hc/en-us/requests/new">here</a>')
 
-    @override_settings(ANALYTICS_DATA_URL='dummy_url')
-    @override_settings(ZENDESK_URL='https://stanfordonline.zendesk.com')
+    @override_settings(ANALYTICS_DATA_URL='dummy_url',
+                       ZENDESK_URL='https://stanfordonline.zendesk.com')
     @patch('courseware.views.process_analytics_answer_dist')
     @patch('courseware.views.Client')
     def test_staff_and_url(self, mock_client, mock_process_analytics):
 
-        mock_client.return_value.modules.return_value.answer_distribution.return_value = [
-            {
-            },
-        ]
+        mock_client.return_value.modules.return_value.answer_distribution.return_value = [{}]
 
         factory = self.factory
         request = factory.post('', self.data)
@@ -73,16 +70,13 @@ class InlineAnalyticsTest(ModuleStoreTestCase):
         response = get_analytics_answer_dist(request)
         self.assertEquals(response, [{'dummy': 'dummy'}])
 
-    @override_settings(ANALYTICS_DATA_URL='dummy_url')
-    @override_settings(ZENDESK_URL='https://stanfordonline.zendesk.com')
+    @override_settings(ANALYTICS_DATA_URL='dummy_url',
+                       ZENDESK_URL='https://stanfordonline.zendesk.com')
     @patch('courseware.views.process_analytics_answer_dist')
     @patch('courseware.views.Client')
     def test_instructor_and_url(self, mock_client, mock_process_analytics):
 
-        mock_client.return_value.modules.return_value.answer_distribution.return_value = [
-            {
-            },
-        ]
+        mock_client.return_value.modules.return_value.answer_distribution.return_value = [{}]
 
         factory = self.factory
         request = factory.post('', self.data)
@@ -101,7 +95,7 @@ class InlineAnalyticsTest(ModuleStoreTestCase):
                 "part_id": "i4x-A-B-problem-f3ed0ba7f89445ee9a83541e1fc8a2f2_2_1",
                 "correct": False,
                 "first_response_count": 7,
-                "final_response_count": 2,
+                "last_response_count": 2,
                 "value_id": "choice_0",
                 "answer_value_text": "Option 1",
                 "answer_value_numeric": "null",
@@ -114,7 +108,7 @@ class InlineAnalyticsTest(ModuleStoreTestCase):
                 "part_id": "i4x-A-B-problem-f3ed0ba7f89445ee9a83541e1fc8a2f2_2_1",
                 "correct": True,
                 "first_response_count": 23,
-                "final_response_count": 25,
+                "last_response_count": 25,
                 "value_id": "choice_1",
                 "answer_value_text": "Option 2",
                 "answer_value_numeric": "null",
@@ -175,7 +169,7 @@ class InlineAnalyticsTest(ModuleStoreTestCase):
                 "part_id": "i4x-A-B-problem-f3ed0ba7f89445ee9a83541e1fc8a2f2_2_1",
                 "correct": False,
                 "first_response_count": 1,
-                "final_response_count": 7,
+                "last_response_count": 7,
                 "value_id": "choice_0",
                 "answer_value_text": "Option 1",
                 "answer_value_numeric": "null",
@@ -243,7 +237,7 @@ class InlineAnalyticsTest(ModuleStoreTestCase):
                 "part_id": "i4x-A-B-problem-f3ed0ba7f89445ee9a83541e1fc8a2f2_2_1",
                 "correct": True,
                 "first_response_count": 18,
-                "final_response_count": 23,
+                "last_response_count": 23,
                 "value_id": "choice_1",
                 "answer_value_text": "Option 2",
                 "answer_value_numeric": "null",

--- a/lms/djangoapps/courseware/tests/test_module_render.py
+++ b/lms/djangoapps/courseware/tests/test_module_render.py
@@ -1106,7 +1106,7 @@ class TestRebindModule(TestSubmittingProblems):
 
 
 @override_settings(MODULESTORE=TEST_DATA_MIXED_MODULESTORE)
-@override_settings(ANALYTICS_ANSWER_DIST_URL=True)
+@override_settings(ANALYTICS_DATA_URL=True)
 class TestInlineAnalytics(ModuleStoreTestCase):
     """Tests to verify that Inline Analytics fragment is generated correctly"""
 

--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -1237,13 +1237,13 @@ def process_analytics_answer_dist(data, question_types_by_part, num_options_by_p
             'totalLastIncorrectCount': 0,
         })
         count_dict['totalFirstAttemptCount'] = count_dict.get('totalFirstAttemptCount') + item['first_response_count']
-        count_dict['totalLastAttemptCount'] = count_dict.get('totalLastAttemptCount') + item['final_response_count']
+        count_dict['totalLastAttemptCount'] = count_dict.get('totalLastAttemptCount') + item['last_response_count']
         if item['correct']:
             count_dict['totalFirstCorrectCount'] = count_dict.get('totalFirstCorrectCount') + item['first_response_count']
-            count_dict['totalLastCorrectCount'] = count_dict.get('totalLastCorrectCount') + item['final_response_count']
+            count_dict['totalLastCorrectCount'] = count_dict.get('totalLastCorrectCount') + item['last_response_count']
         else:
             count_dict['totalFirstIncorrectCount'] = count_dict.get('totalFirstIncorrectCount') + item['first_response_count']
-            count_dict['totalLastIncorrectCount'] = count_dict.get('totalLastIncorrectCount') + item['final_response_count']
+            count_dict['totalLastIncorrectCount'] = count_dict.get('totalLastIncorrectCount') + item['last_response_count']
 
         count_by_part[part_id] = count_dict
 
@@ -1252,7 +1252,7 @@ def process_analytics_answer_dist(data, question_types_by_part, num_options_by_p
         part_dict['value_id'] = item['value_id']
         part_dict['correct'] = item['correct']
         part_dict['first_count'] = item['first_response_count']
-        part_dict['last_count'] = item['final_response_count']
+        part_dict['last_count'] = item['last_response_count']
 
         data_by_part[part_id] = data_by_part.get(part_id, []) + [part_dict]
 

--- a/lms/static/js/inline_analytics.js
+++ b/lms/static/js/inline_analytics.js
@@ -36,16 +36,16 @@ window.InlineAnalytics = (function() {
             }
 
             if (countByPart[partId]) {
-            	totalFirstAttemptCount = countByPart[partId]['totalFirstAttemptCount'];
-            	totalFirstCorrectCount = countByPart[partId]['totalFirstCorrectCount'];
-            	totalFirstIncorrectCount = countByPart[partId]['totalFirstIncorrectCount'];
+                totalFirstAttemptCount = countByPart[partId]['totalFirstAttemptCount'];
+                totalFirstCorrectCount = countByPart[partId]['totalFirstCorrectCount'];
+                totalFirstIncorrectCount = countByPart[partId]['totalFirstIncorrectCount'];
                 totalLastAttemptCount = countByPart[partId]['totalLastAttemptCount'];
                 totalLastCorrectCount = countByPart[partId]['totalLastCorrectCount'];
                 totalLastIncorrectCount = countByPart[partId]['totalLastIncorrectCount'];
             } else {
-            	totalFirstAttemptCount = 0;
-            	totalFirstCorrectCount = 0;
-            	totalFirstIncorrectCount = 0;
+                totalFirstAttemptCount = 0;
+                totalFirstCorrectCount = 0;
+                totalFirstIncorrectCount = 0;
                 totalLastAttemptCount = 0;
                 totalLastCorrectCount = 0;
                 totalLastIncorrectCount = 0;
@@ -271,7 +271,7 @@ window.InlineAnalytics = (function() {
         correctResponse,
         lastUpdateDate) {
 
-    	var firstCount;
+        var firstCount;
         var lastCount;
         var firstPercent;
         var lastPercent;

--- a/lms/static/js/inline_analytics.js
+++ b/lms/static/js/inline_analytics.js
@@ -13,9 +13,12 @@ window.InlineAnalytics = (function() {
         var countByPart = response.count_by_part;
         var messageByPart = response.message_by_part;
         var lastUpdateDate = response.last_update_date;
-        var totalAttemptCount;
-        var totalCorrectCount;
-        var totalIncorrectCount;
+        var totalFirstAttemptCount;
+        var totalFirstCorrectCount;
+        var totalFirstIncorrectCount;
+        var totalLastAttemptCount;
+        var totalLastCorrectCount;
+        var totalLastIncorrectCount;
 
         var partId;
         var index;
@@ -33,22 +36,27 @@ window.InlineAnalytics = (function() {
             }
 
             if (countByPart[partId]) {
-                totalAttemptCount = countByPart[partId]['totalAttemptCount'];
-                totalCorrectCount = countByPart[partId]['totalCorrectCount'];
-                totalIncorrectCount = countByPart[partId]['totalIncorrectCount'];
+            	totalFirstAttemptCount = countByPart[partId]['totalFirstAttemptCount'];
+            	totalFirstCorrectCount = countByPart[partId]['totalFirstCorrectCount'];
+            	totalFirstIncorrectCount = countByPart[partId]['totalFirstIncorrectCount'];
+                totalLastAttemptCount = countByPart[partId]['totalLastAttemptCount'];
+                totalLastCorrectCount = countByPart[partId]['totalLastCorrectCount'];
+                totalLastIncorrectCount = countByPart[partId]['totalLastIncorrectCount'];
             } else {
-                totalAttemptCount = 0;
-                totalCorrectCount = 0;
-                totalIncorrectCount = 0;
+            	totalFirstAttemptCount = 0;
+            	totalFirstCorrectCount = 0;
+            	totalFirstIncorrectCount = 0;
+                totalLastAttemptCount = 0;
+                totalLastCorrectCount = 0;
+                totalLastIncorrectCount = 0;
             }
 
             if (questionTypesByPart[partId] === 'radio') {
                 renderRadioAnalytics(
                     dataByPart[partId],
                     partId,
-                    totalAttemptCount,
-                    totalCorrectCount,
-                    totalIncorrectCount,
+                    totalFirstAttemptCount,
+                    totalLastAttemptCount,
                     correctResponses[partId],
                     lastUpdateDate,
                     choiceNameListByPart[partId]);
@@ -56,23 +64,25 @@ window.InlineAnalytics = (function() {
                 renderCheckboxAnalytics(
                     dataByPart[partId],
                     partId,
-                    totalAttemptCount,
-                    totalCorrectCount,
-                    totalIncorrectCount,
+                    totalFirstAttemptCount,
+                    totalLastAttemptCount,
                     correctResponses[partId],
                     lastUpdateDate);
             } else {
                 // Just set the text on the div
                 setCountAndDate(
                     partId,
-                    totalAttemptCount,
+                    totalLastAttemptCount,
                     lastUpdateDate);
 
                 setAggregateCounts(
                     partId,
-                    totalAttemptCount,
-                    totalCorrectCount,
-                    totalIncorrectCount);
+                    totalFirstAttemptCount,
+                    totalFirstCorrectCount,
+                    totalFirstIncorrectCount,
+                    totalLastAttemptCount,
+                    totalLastCorrectCount,
+                    totalLastIncorrectCount);
             }
         }
     }
@@ -81,9 +91,8 @@ window.InlineAnalytics = (function() {
     function renderRadioAnalytics(
         result,
         partId,
-        totalAttemptCount,
-        totalCorrectCount,
-        totalIncorrectCount,
+        totalFirstAttemptCount,
+        totalLastAttemptCount,
         correctResponse,
         lastUpdateDate,
         choiceNameString) {
@@ -93,19 +102,23 @@ window.InlineAnalytics = (function() {
         var valueIndex;
         var lastIndex;
         var correct;
-        var count;
-        var percent;
+        var firstCount;
+        var lastCount;
+        var firstPercent;
+        var lastPercent;
         var answerClass;
         var index;
         var tr;
         var tdChoice;
         var tdDot;
-        var tdCount;
-        var tdPercent;
+        var tdFirstCount;
+        var tdLastCount;
+        var tdFirstPercent;
+        var tdLastPercent;
         var trs = [];
         var valueIdArray;
         var arrayLength;
-        var lastRow = $('#' + partId + '_table tr:last');
+        var lastTableRow = $('#' + partId + '_table tr:last');
         var currentResult;
 
         // Build the array of choice texts
@@ -136,8 +149,10 @@ window.InlineAnalytics = (function() {
                 } else {
                     currentResult = result[valueIdArray.indexOf(choiceNameArray[index])]
                     correct = currentResult['correct'];
-                    count = currentResult['count'];
-                    percent = Math.round(count * 1000 / (totalAttemptCount * 10));
+                    firstCount = currentResult['first_count'];
+                    lastCount = currentResult['last_count'];
+                    firstPercent = Math.round(firstCount * 1000 / (totalFirstAttemptCount * 10));
+                    lastPercent = Math.round(lastCount * 1000 / (totalLastAttemptCount * 10));
 
                     if (correct) {
                         answerClass = 'inline-analytics-correct';
@@ -152,15 +167,21 @@ window.InlineAnalytics = (function() {
                     tdDot = $('<td class="answer_box">');
                     tdDot.addClass(answerClass);
                     tdDot.append($('<span class="dot">'));
-                    tdCount = $('<td class="answer_box">');
-                    tdCount.text(count);
-                    tdPercent = $('<td class="answer_box">');
-                    tdPercent.text(percent + '%');
+                    tdFirstCount = $('<td class="checkbox_first_attempt">');
+                    tdFirstCount.text(firstCount);
+                    tdFirstPercent = $('<td class="checkbox_first_attempt">');
+                    tdFirstPercent.text(firstPercent + '%');
+                    tdLastCount = $('<td class="checkbox_last_attempt">');
+                    tdLastCount.text(lastCount);
+                    tdLastPercent = $('<td class="checkbox_last_attempt">');
+                    tdLastPercent.text(lastPercent + '%');
                     
                     tr.append(tdChoice);
                     tr.append(tdDot);
-                    tr.append(tdCount);
-                    tr.append(tdPercent);
+                    tr.append(tdFirstCount);
+                    tr.append(tdFirstPercent);
+                    tr.append(tdLastCount);
+                    tr.append(tdLastPercent);
                     trs.push(tr[0]);
                 }
             }
@@ -176,11 +197,11 @@ window.InlineAnalytics = (function() {
         }
 
         // Append the row array to the table
-        lastRow.after(trs);
+        lastTableRow.after(trs);
 
         // Set student count and last_update_date
         setCountAndDate(partId,
-            totalAttemptCount,
+            totalLastAttemptCount,
             lastUpdateDate);
     }
 
@@ -198,8 +219,10 @@ window.InlineAnalytics = (function() {
         var tr;
         var tdChoice;
         var tdDot;
-        var tdCount;
-        var tdPercent;
+        var tdFirstCount;
+        var tdLastCount;
+        var tdFirstPercent;
+        var tdLastPercent;
         
         correctResponse = correctResponse.substring(2, correctResponse.length - 2);
 
@@ -218,15 +241,21 @@ window.InlineAnalytics = (function() {
             tdDot = $('<td class="answer_box">');
             tdDot.addClass(answerClass);
             tdDot.append($('<span class="dot">'));
-            tdCount = $('<td class="answer_box">');
-            tdCount.text(0);
-            tdPercent = $('<td class="answer_box">');
-            tdPercent.text('0%');
+            tdFirstCount = $('<td class="checkbox_first_attempt">');
+            tdFirstCount.text(0);
+            tdLastCount = $('<td class="checkbox_last_attempt">');
+            tdLastCount.text(0);
+            tdFirstPercent = $('<td class="checkbox_first_attempt">');
+            tdFirstPercent.text('0%');
+            tdLastPercent = $('<td class="checkbox_last_attempt">');
+            tdLastPercent.text('0%');
             
             tr.append(tdChoice);
             tr.append(tdDot);
-            tr.append(tdCount);
-            tr.append(tdPercent);
+            tr.append(tdFirstCount);
+            tr.append(tdFirstPercent);
+            tr.append(tdLastCount);
+            tr.append(tdLastPercent);
             trs.push(tr[0]);
             currentIndex += 1;
         }
@@ -237,19 +266,21 @@ window.InlineAnalytics = (function() {
     function renderCheckboxAnalytics(
         result,
         partId,
-        totalAttemptCount,
-        totalCorrectCount,
-        totalIncorrectCount,
+        totalFirstAttemptCount,
+        totalLastAttemptCount,
         correctResponse,
         lastUpdateDate) {
 
-        var count;
-        var percent;
+    	var firstCount;
+        var lastCount;
+        var firstPercent;
+        var lastPercent;
         var answerClass;
         var actualResponse;
         var imaginedResponse;
         var checkboxChecked;
-        var countRow;
+        var firstCountRow;
+        var lastCountRow;
         var index;
         var maxColumns = 10;
         var choiceCounter = 1;
@@ -264,7 +295,10 @@ window.InlineAnalytics = (function() {
         // Add "Last Attempt" to the choice number column
         $('#' + partId + '_table .checkbox_header_row').after('<tr><td id="last_attempt" class="answer_box checkbox_last_attempt">Last Attempt</td></tr>');
 
-        // Contruct the choice number column array
+        // Add "First Attempt" to the choice number column
+        $('#' + partId + '_table .checkbox_header_row').after('<tr><td id="first_attempt" class="answer_box checkbox_first_attempt">First Attempt</td></tr>');
+        
+        // Construct the choice number column array
         while (choiceCounter <= choiceText.length) {
             tr = $('<tr><td id="column0:row' + choiceCounter + '" class="answer_box" title="' +
                 choiceText[choiceCounter - 1] + '">' + choiceCounter + '</td></tr>');
@@ -278,7 +312,7 @@ window.InlineAnalytics = (function() {
 
         // Loop through results constructing header row and data row arrays
         if (result) {
-            // Sort the results in decending response count order
+            // Sort the results in descending response count order
             result.sort(orderByCount);
 
             var arrayLength = result.length;
@@ -323,11 +357,15 @@ window.InlineAnalytics = (function() {
 
                     choiceCounter += 1;
                 }
-
+                // Construct the First Attempt row
+                firstCount = result[index]['first_count'];
+                firstPercent = Math.round(firstCount * 1000 / (totalFirstAttemptCount * 10));
+                firstCountRow += '<td class="checkbox_first_attempt">' + firstCount + '<br/>' + firstPercent + '%</td>'
+                
                 // Construct the Last Attempt row
-                count = result[index]['count'];
-                percent = Math.round(count * 1000 / (totalAttemptCount * 10));
-                countRow += '<td class="answer_box">' + count + '<br/>' + percent + '%</td>'
+                lastCount = result[index]['last_count'];
+                lastPercent = Math.round(lastCount * 1000 / (totalLastAttemptCount * 10));
+                lastCountRow += '<td class="checkbox_last_attempt">' + lastCount + '<br/>' + lastPercent + '%</td>'
             }
 
             // Append the header row array to the header row
@@ -349,13 +387,16 @@ window.InlineAnalytics = (function() {
             }
 
         }
+        //Append count row to the first attempt row
+        $('#' + partId + '_table #first_attempt').after(firstCountRow);
+        
         // Append count row to the last attempt row
-        $('#' + partId + '_table #last_attempt').after(countRow);
+        $('#' + partId + '_table #last_attempt').after(lastCountRow);
 
         // Set student count and last_update_date
         setCountAndDate(
             partId,
-            totalAttemptCount,
+            totalLastAttemptCount,
             lastUpdateDate);
     }
 
@@ -374,13 +415,13 @@ window.InlineAnalytics = (function() {
 
     function setCountAndDate(
         partId,
-        totalAttemptCount,
+        totalLastAttemptCount,
         lastUpdateDate) {
 
         // Set the Count and Date
         var part = document.getElementById(partId + '_analytics');
         part = $(part);
-        part.find('.num-students').text(totalAttemptCount);
+        part.find('.num-students').text(totalLastAttemptCount);
         part.find('.last-update').text(lastUpdateDate);
 
     }
@@ -388,26 +429,37 @@ window.InlineAnalytics = (function() {
 
     function setAggregateCounts(
         partId,
-        totalAttemptCount,
-        totalCorrectCount,
-        totalIncorrectCount) {
+        totalFirstAttemptCount,
+        totalFirstCorrectCount,
+        totalFirstIncorrectCount,
+        totalLastAttemptCount,
+        totalLastCorrectCount,
+        totalLastIncorrectCount) {
 
         // Set text information for questions that have no inline analytics
         // graphics (not radio or checkbox)
         var part = document.getElementById(partId + '_analytics');
         part = $(part);
-        var correctPercent = Math.round(totalCorrectCount * 1000 / (totalAttemptCount * 10));
-        var incorrectPercent = Math.round(totalIncorrectCount * 1000 / (totalAttemptCount * 10));
-        part.find('.num-students-extra').text(totalCorrectCount + ' (' + correctPercent + '%) correct and ' +
-            totalIncorrectCount + ' (' + incorrectPercent + '%) incorrect.');
+        
+        var correctFirstPercent = Math.round(totalFirstCorrectCount * 1000 / (totalFirstAttemptCount * 10));
+        var incorrectFirstPercent = Math.round(totalFirstIncorrectCount * 1000 / (totalFirstAttemptCount * 10));    
+        
+        var correctLastPercent = Math.round(totalLastCorrectCount * 1000 / (totalLastAttemptCount * 10));
+        var incorrectLastPercent = Math.round(totalLastIncorrectCount * 1000 / (totalLastAttemptCount * 10));
+        
+        part.find('.num-students-extra-first').text(totalFirstCorrectCount + ' (' + correctFirstPercent + '%) correct and ' +
+                totalFirstIncorrectCount + ' (' + incorrectFirstPercent + '%) incorrect (First Attempt).');
+        
+        part.find('.num-students-extra-last').text(totalLastCorrectCount + ' (' + correctLastPercent + '%) correct and ' +
+            totalLastIncorrectCount + ' (' + incorrectLastPercent + '%) incorrect (Last Attempt).');
     }
 
 
     function orderByCount(a, b) {
-        if (a['count'] > b['count']) {
+        if (a['last_count'] > b['last_count']) {
             return -1;
         }
-        if (a['count'] < b['count']) {
+        if (a['last_count'] < b['last_count']) {
             return 1;
         }
         return 0;

--- a/lms/static/sass/course/courseware/_instructor.scss
+++ b/lms/static/sass/course/courseware/_instructor.scss
@@ -83,6 +83,14 @@
     text-align: center;
 }
 
+.checkbox_first_attempt {
+    background-color:#dedede;
+}
+
+.checkbox_last_attempt {
+    background-color:#c2c2c2;
+}
+
 .inline-analytics-incorrect {
     background-color:#ffa4a2;
 }

--- a/lms/templates/inline_analytics.html
+++ b/lms/templates/inline_analytics.html
@@ -25,9 +25,9 @@ ${block_content}
         <section aria-hidden="true" >
           <div class="grid-wrapper radio">
             <p>
-              ${_('{title}').format(title=u'Answer distribution of the <strong class="num-students"></strong> students who answered this question.')}
+              ${_('Answer distribution of the {num_students} students who answered this question.').format(num_students='<strong class="num-students"></strong>')}
             </p>
-            <p>${_('Last updated: ')}<strong class="last-update"></strong></p>
+            <p>${_('Last updated:')} <strong class="last-update"></strong></p>
             <div class="grid-block table">
               <table cellspacing="2px" id="${part_id}_table" class="analytics-table">
                 <tr>
@@ -46,9 +46,9 @@ ${block_content}
         <section aria-hidden="true" >
           <div class="grid-wrapper checkbox">
             <p>
-              ${_('{title}').format(title=u'Answer distribution of the <strong class="num-students"></strong> students who answered this question.')}
+              ${_('Answer distribution of the {num_students} students who answered this question.').format(num_students='<strong class="num-students"></strong>')}
             </p>
-            <p>${_('Last updated: ')}<strong class="last-update"></strong></p>
+            <p>${_('Last updated:')} <strong class="last-update"></strong></p>
             <div class="grid-block table">
               <table cellspacing="2px" id="${part_id}_table" class="analytics-table">
                 <tr class="checkbox_header_row">
@@ -64,11 +64,11 @@ ${block_content}
         <section aria-hidden="true" >
           <div class="grid-wrapper">
             <p>
-              <strong class="num-students"></strong>${_(' students answered this question:')}<br/>
-              <strong class="num-students-extra-first"></strong> <br/>
+              <strong class="num-students"></strong> ${_('students answered this question:')}<br/>
+              <strong class="num-students-extra-first"></strong><br/>
               <strong class="num-students-extra-last"></strong>
             </p>
-            <p>${_('Last updated: ')}<strong class="last-update"></strong></p>
+            <p>${_('Last updated:')} <strong class="last-update"></strong></p>
           </div>
         </section>
       </div>

--- a/lms/templates/inline_analytics.html
+++ b/lms/templates/inline_analytics.html
@@ -24,14 +24,17 @@ ${block_content}
       <div id="${part_id}_analytics" class="${element_id}_analytics_div inline-analytics-item" data-correct-response="${correct_response}" data-question-type="${question_type}" data-choice-name-list="${choice_name_list}">
         <section aria-hidden="true" >
           <div class="grid-wrapper radio">
-            <p>Answer distribution of the <strong class="num-students"></strong> students who answered this question.</p>
-            <p>Last updated: <strong class="last-update"></strong></p>
+            <p>
+              ${_('{title}').format(title=u'Answer distribution of the <strong class="num-students"></strong> students who answered this question.')}
+            </p>
+            <p>${_('Last updated: ')}<strong class="last-update"></strong></p>
             <div class="grid-block table">
               <table cellspacing="2px" id="${part_id}_table" class="analytics-table">
                 <tr>
-                  <td width="65px">Choice</td>
+                  <td width="65px">${_('Choice')}</td>
                   <td width="50px"></td>
-                  <td width="125px" colspan="2">Last Attempt</td>
+                  <td width="125px" colspan="2">${_('First Attempt')}</td>
+                  <td width="125px" colspan="2">${_('Last Attempt')}</td>
                 </tr>
               </table>
             </div>
@@ -42,12 +45,14 @@ ${block_content}
       <div id="${part_id}_analytics" class="${element_id}_analytics_div inline-analytics-item" data-correct-response="${correct_response}" data-question-type="${question_type}">
         <section aria-hidden="true" >
           <div class="grid-wrapper checkbox">
-            <p>Answer distribution of the <strong class="num-students"></strong> students who answered this question:</p>
-            <p>Last updated: <strong class="last-update"></strong></p>
+            <p>
+              ${_('{title}').format(title=u'Answer distribution of the <strong class="num-students"></strong> students who answered this question.')}
+            </p>
+            <p>${_('Last updated: ')}<strong class="last-update"></strong></p>
             <div class="grid-block table">
               <table cellspacing="2px" id="${part_id}_table" class="analytics-table">
                 <tr class="checkbox_header_row">
-                  <td width="65px">Choice</td>
+                  <td width="65px">${_('Choice')}</td>
                 </tr>
               </table>
             </div>
@@ -59,10 +64,11 @@ ${block_content}
         <section aria-hidden="true" >
           <div class="grid-wrapper">
             <p>
-              <strong class="num-students"></strong> students answered this question: <br/>
-              <strong class="num-students-extra"></strong>
+              <strong class="num-students"></strong>${_(' students answered this question:')}<br/>
+              <strong class="num-students-extra-first"></strong> <br/>
+              <strong class="num-students-extra-last"></strong>
             </p>
-            <p>Last updated: <strong class="last-update"></strong></p>
+            <p>${_('Last updated: ')}<strong class="last-update"></strong></p>
           </div>
         </section>
       </div>


### PR DESCRIPTION
Adds first attempt data to in-line analytics

For both radio and checkbox types first attempt data has been added
to the existing last attempt data.

For other line item display types the first attempt data is listed.

Part of the implementation includes changing to use the api client
rather than the api itself.