### PR TITLE
If student has authenticated using shib remove edit Full Name link on dash

### DIFF
--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -82,7 +82,11 @@
     <section class="user-info">
       <ul>
         <li class="info--username">
-          <span class="title">${_("Full Name")} (<a href="#apply_name_change" rel="leanModal" class="edit-name">${_("edit")}</a>)</span> <span class="data">${ user.profile.name | h }</span>
+          % if external_auth_map is None or 'shib' not in external_auth_map.external_domain:
+            <span class="title">${_("Full Name")} (<a href="#apply_name_change" rel="leanModal" class="edit-name">${_("edit")}</a>)</span> <span class="data">${ user.profile.name | h }</span>
+          % else:
+            <span class="title">${_("Full Name")} </span> <span class="data">${ user.profile.name | h }</span>
+          % endif
         </li>
         <li class="info--email">
           <span class="title">${_("Email")}


### PR DESCRIPTION
If student has authenticated using shib remove edit Full Name link on dash.

This change is primarily required for suclass. Students always login through
Shib and so their name in suclass is propagated from WebAuth.