### PR TITLE
Add Management Commands tab to sysadmin page

### DIFF
--- a/lms/djangoapps/dashboard/sysadmin_urls.py
+++ b/lms/djangoapps/dashboard/sysadmin_urls.py
@@ -16,4 +16,5 @@ urlpatterns = patterns(
     url(r'^gitlogs/(?P<course_id>.+)$', sysadmin.GitLogs.as_view(),
         name="gitlogs_detail"),
     url(r'^task_queue/?$', sysadmin.TaskQueue.as_view(), name="sysadmin_task_queue"),
+    url(r'^mgmt_commands/?$', sysadmin.MgmtCommands.as_view(), name="sysadmin_mgmt_commands"),
 )

--- a/lms/djangoapps/dashboard/tests/test_sysadmin_mgmt_commands.py
+++ b/lms/djangoapps/dashboard/tests/test_sysadmin_mgmt_commands.py
@@ -1,0 +1,53 @@
+"""
+Tests for the Mgmt Commands Feature on the Sysadmin page
+"""
+import json
+from mock import patch
+import unittest
+
+from django.conf import settings
+from django.core.urlresolvers import reverse
+
+from dashboard.tests.test_sysadmin import SysadminBaseTestCase
+
+
+@unittest.skipUnless(
+    settings.FEATURES.get('ENABLE_SYSADMIN_DASHBOARD'),
+    'ENABLE_SYSADMIN_DASHBOARD not set',
+)
+class TestSysadminMgmtCommands(SysadminBaseTestCase):
+    """Tests all code paths in Sysadmin Mgmt Commands"""
+
+    def setUp(self):
+        super(TestSysadminMgmtCommands, self).setUp()
+        self._setsuperuser_login()
+        self.post_params = {
+            'command': 'fake_command',
+            'key1': 'value1',
+            'key2': 'value2',
+            'kwflags': ['kwflag1', 'kwflag2'],
+            'args': ['arg1', 'arg2'],
+        }
+
+    def _setsuperuser_login(self):
+        """Makes the test user a superuser and logs them in"""
+        self.user.is_superuser = True
+        self.user.save()
+        self.client.login(username=self.user.username, password='foo')
+
+    def test_mgmt_commands_handles_systemexit(self):
+        with patch('dashboard.sysadmin.call_command') as call_command:
+            call_command.side_effect = SystemExit()
+            response = self.client.post(reverse('sysadmin_mgmt_commands'), self.post_params)
+            self.assertEqual('Command failed', json.loads(response.content.decode('utf-8'))['error'])
+
+    def test_mgmt_commands_handles_exception(self):
+        with patch('dashboard.sysadmin.call_command') as call_command:
+            call_command.side_effect = Exception('Unknown exception')
+            response = self.client.post(reverse('sysadmin_mgmt_commands'), self.post_params)
+            self.assertEqual('Unknown exception', json.loads(response.content.decode('utf-8'))['error'])
+
+    def test_mgmt_commands_correct_arguments(self):
+        with patch('dashboard.sysadmin.call_command') as call_command:
+            self.client.post(reverse('sysadmin_mgmt_commands'), self.post_params)
+            call_command.assert_called_with('fake_command', 'arg1', 'arg2', key1='value1', key2='value2', kwflag1=None, kwflag2=None)

--- a/lms/static/js/sysadmin/mgmt_commands.js
+++ b/lms/static/js/sysadmin/mgmt_commands.js
@@ -1,0 +1,305 @@
+(function () {
+    var commands = [
+        {
+            'display_name': gettext('Whitelist a user'),
+            'method': 'cert_whitelist',
+            'description': gettext('Add a user to the whitelist for a course'),
+            'kwargs': [
+                {
+                    'argument': 'add',
+                    'display_name': gettext('username'),
+                    'required': true
+                },
+                {
+                    'argument': 'course_id',
+                    'display_name': gettext('course_id'),
+                    'required': true
+                }
+            ]
+        },
+        {
+            'display_name': gettext('De-whitelist a user'),
+            'method': 'cert_whitelist',
+            'description': gettext('Remove a user from the whitelist for a course'),
+            'kwargs': [
+                {
+                    'argument': 'del',
+                    'display_name': gettext('username'),
+                    'required': true
+                },
+                {
+                    'argument': 'course_id',
+                    'display_name': gettext('course_id'),
+                    'required': true
+                }
+            ]
+        },
+        {
+            'display_name': gettext('Generate a single certificate'),
+            'method': 'regenerate_user',
+            'description': gettext('Put a request on the queue to recreate the certificate for a particular user in a particular course'),
+            'kwargs': [
+                {
+                    'argument': 'course',
+                    'display_name': gettext('course_id'),
+                    'required': true
+                },
+                {
+                    'argument': 'username',
+                    'display_name': gettext('username'),
+                    'required': true
+                },
+                {
+                    'argument': 'grade',
+                    'display_name': gettext('grade'),
+                    'required': true
+                },
+                {
+                    'argument': 'template',
+                    'display_name': gettext('template'),
+                    'required': true
+                },
+            ]
+        },
+        {
+            'display_name': gettext('Do a certificate run for a course'),
+            'method': 'ungenerated_certs',
+            'description': gettext('Find all students that need certificates for courses that have finished and put their cert requests on the queue.'),
+            'kwargs': [
+                {
+                    'argument': 'course',
+                    'display_name': 'course_id',
+                    'required': true
+                },
+            ]
+        },
+    ]
+
+    function commandChanged(e){
+        var command_key = $(e.target).val();
+        loadCommand(command_key);
+    }
+
+    function updateElementWithContent($element, content){
+        var paragraph = $(document.createElement('p'));
+        paragraph.addClass($element.attr('output-type'));
+        paragraph.html(content.replace(/(?:\r\n|\r|\n)/g, '<br />'));
+        $element.append(paragraph);
+    }
+
+    function submitForm(event){
+        var button = $(event.target);
+        button.prop('disabled',true);
+        var form = $('#command-form');
+
+        $.ajax({
+            url: '/sysadmin/mgmt_commands/',
+            type: 'POST',
+            data: form.serialize(),
+            dataType: 'json',
+            success: function(data) {
+
+                $errorBox = $('.mgmt-commands-body .error');
+                $stdErrLogBox = $('.mgmt-commands-body .stderr');
+                $stdOutLogBox = $('.mgmt-commands-body .stdout');
+
+                $errorBox.html('<h3 class="error">Errors:</h3>');
+                $stdErrLogBox.html('<h3 class="stderr">Std Error:</h3>');
+                $stdOutLogBox.html('<h3 class="stdout">Std Out:</h3>');
+
+                if (data.error != null){
+                    updateElementWithContent($errorBox, data.error);
+                }
+                if (data.stderr != null){
+                    updateElementWithContent($stdErrLogBox, data.stderr);
+                }
+                if (data.stdout != null){
+                    updateElementWithContent($stdOutLogBox, data.stdout);
+                }
+                button.prop('disabled', false);
+            },
+            error: function(std_ajax_err) {
+              console.log('Management Command failed to execute');
+            }
+        });
+    }
+
+    function generateInputRow(arg, type){
+        var $inputRow = $(document.createElement('div'));
+        $inputRow.addClass('form-actions')
+        var label = $(document.createElement('label'));
+        label.html(arg.display_name);
+        if (arg.required){
+            label.append('<span>*</span>')
+        }
+
+        var input = $(document.createElement('input'));
+
+        if (type == 'kwarg'){
+
+            label.attr('for', arg.argument);
+            input.attr('type', 'text');
+            input.addClass('textfield-tag');
+            input.attr('name', arg.argument);
+            $inputRow.append(label);
+            $inputRow.append(input);
+        }
+        else if (type == 'kwflag'){
+            label.attr('for', 'kwflags');
+            label.addClass('checkbox-label');
+            input.attr('type', 'checkbox');
+            input.attr('name', 'kwflags');
+            input.val(arg.argument);
+            $inputRow.append(input);
+            $inputRow.append(label);
+        }
+        else if (type === 'arg'){
+            label.attr('for', 'args');
+            input.attr('type', 'text');
+            input.addClass('textfield-tag');
+            input.attr('name', 'args');
+            $inputRow.append(label);
+            $inputRow.append(input);
+        }
+
+
+        return $inputRow;
+    }
+
+    function loadCommand(command_key){
+        var command = commands[command_key];
+        //update description
+        $('#command-description').text(command.description);
+
+        //update form
+        var $form_fieldset = $('#form-fieldset');
+        $form_fieldset.html('');
+        var legend = $(document.createElement('legend'));
+        legend.html(command.display_name);
+        $form_fieldset.append(legend);
+        if (command.kwargs && command.kwargs.length> 0){
+            $form_fieldset.append('<h4>Keyword Arguments:</h4>');
+        }
+        for (var key in command.kwargs){
+            var kwarg = command.kwargs[key];
+            var inputRow = generateInputRow(kwarg, 'kwarg');
+            $form_fieldset.append(inputRow);
+        }
+        if (command.kwflags && command.kwflags.length > 0){
+            $form_fieldset.append('<h4 class="new-section">Keyword Flags:</h4>');
+        }
+        for (var key in command.kwflags){
+            var kwflag = command.kwflags[key];
+            var inputRow = generateInputRow(kwflag, 'kwflag');
+            $form_fieldset.append(inputRow);
+        }
+        if (command.args && command.args.length > 0){
+            $form_fieldset.append('<h4 class="new-section">Arguments:<h4>');
+        }
+        for (var key in command.args){
+            var arg = command.args[key];
+            var inputRow = generateInputRow(arg, 'arg');
+            $form_fieldset.append(inputRow);
+        }
+        var commandName = $(document.createElement('input'));
+        commandName.attr({
+                type: 'hidden',
+                name: 'command'
+        });
+        commandName.val(command.method);
+        $form_fieldset.append(commandName);
+
+        var submitButton = $(document.createElement('button'));
+        submitButton.addClass('execute-command-button');
+        submitButton.attr('type', 'button');
+        submitButton.val('execute_command');
+        submitButton.html(gettext('Execute Command'));
+
+        submitButton.click(submitForm)
+        $form_fieldset.append(submitButton);
+
+    }
+
+    function createSelectDiv(){
+        var selectDiv = $(document.createElement('div'));
+        selectDiv.addClass('command-selector');
+        var selectTag = $(document.createElement('select'));
+        selectTag.addClass('full-width');
+        selectTag.addClass('select-tag');
+
+        for (var key in commands){
+            var command = commands[key];
+            var optionTag = $(document.createElement('option'));
+            optionTag.html(command.display_name);
+            optionTag.val(key);
+            selectTag.append(optionTag);
+        }
+        selectTag.bind("change", commandChanged);
+        selectDiv.append(selectTag);
+
+        var descriptionParagraph = $(document.createElement('p'));
+        descriptionParagraph.html('<h1>description</h1>');
+        descriptionParagraph.attr('id', 'command-description');
+        selectDiv.append(descriptionParagraph);
+
+        return selectDiv;
+    }
+
+    function createFormWrapperDiv(){
+        var formWrapperDiv = $(document.createElement('div'));
+
+        var form = $(document.createElement('form'));
+        form.attr('id', 'command-form');
+
+        var formFieldset = $(document.createElement('fieldset'));
+        formFieldset.attr('id', 'form-fieldset');
+        formFieldset.addClass('bordered-fieldset');
+        form.append(formFieldset);
+
+        formWrapperDiv.append(form);
+
+        return formWrapperDiv;
+    }
+
+    function createOutputConsoleDiv(){
+        var outputConsoleDiv = $(document.createElement('div'));
+        var outputConsoleFieldset = $(document.createElement('fieldset'));
+        outputConsoleFieldset.addClass('bordered-fieldset');
+
+        var outputConsoleLegend = $(document.createElement('legend'));
+        outputConsoleLegend.text('Output Console');
+
+        outputConsoleFieldset.append(outputConsoleLegend);
+        var errorDiv = $(document.createElement('div'));
+        errorDiv.addClass('error');
+        errorDiv.attr('output-type', 'error');
+        var stdErrDiv = $(document.createElement('div'));
+        stdErrDiv.addClass('stderr new-section');
+        stdErrDiv.attr('output-type', 'stderr');
+        var stdOutDiv = $(document.createElement('div'));
+        stdOutDiv.addClass('stdout new-section');
+        stdOutDiv.attr('output-type', 'stdout');
+
+        outputConsoleFieldset.append(errorDiv);
+        outputConsoleFieldset.append(stdErrDiv);
+        outputConsoleFieldset.append(stdOutDiv);
+
+        outputConsoleDiv.append(outputConsoleFieldset);
+        return outputConsoleDiv;
+    }
+
+    function createMarkUp(){
+        $pageBody = $('.mgmt-commands-body');
+        var selectDiv = createSelectDiv();
+        var formWrapperDiv = createFormWrapperDiv();
+        var outputConsoleDiv = createOutputConsoleDiv();
+        $pageBody.append(selectDiv);
+        $pageBody.append(formWrapperDiv);
+        $pageBody.append(outputConsoleDiv);
+    }
+
+    $(function () {
+        createMarkUp();
+        loadCommand(0);
+    });
+})();

--- a/lms/static/sass/application-extend1.scss.mako
+++ b/lms/static/sass/application-extend1.scss.mako
@@ -56,6 +56,7 @@
 @import 'multicourse/help';
 @import 'multicourse/edge';
 @import 'multicourse/survey-page';
+@import 'multicourse/sysadmin';
 
 @import 'developer'; // used for any developer-created scss that needs further polish/refactoring
 @import 'shame';     // used for any bad-form/orphaned scss

--- a/lms/static/sass/multicourse/_sysadmin.scss
+++ b/lms/static/sass/multicourse/_sysadmin.scss
@@ -1,0 +1,51 @@
+.mgmt-commands-body .command-selector {
+    border: solid 4px #000000;
+    padding: 20px;
+}
+
+.mgmt-commands-body .select-tag {
+    height: 35px;
+    font-size: 1.1em;
+}
+
+.mgmt-commands-body .textfield-tag {
+    width: 30%;
+}
+
+.mgmt-commands-body .full-width {
+    width: 100%;
+}
+
+.mgmt-commands-body .bordered-fieldset {
+    border: solid 4px #000000;
+    padding: 20px;
+    margin-top: 30px;
+}
+
+.mgmt-commands-body .execute-command-button {
+    margin-top: 20px;
+}
+
+.mgmt-commands-body #command-description {
+    margin-top: 10px;
+}
+
+.mgmt-commands-body .error {
+    color: #E40004;
+}
+
+.mgmt-commands-body .stderr {
+    color: #800000;
+}
+
+.mgmt-commands-body .stdout {
+    color: #008000;
+}
+
+.mgmt-commands-body .new-section {
+    margin-top: 20px;
+}
+
+.mgmt-commands-body .checkbox-label {
+    display: inline;
+}

--- a/lms/templates/sysadmin_dashboard.html
+++ b/lms/templates/sysadmin_dashboard.html
@@ -7,6 +7,9 @@
   <%static:css group='style-course'/>
   <script type="text/javascript" src="${static.url('js/vendor/flot/jquery.flot.js')}"></script>
   <script type="text/javascript" src="${static.url('js/vendor/flot/jquery.flot.axislabels.js')}"></script>
+  %if modeflag.get('mgmt_commands'):
+      <script type='text/javascript' src="${static.url('js/sysadmin/mgmt_commands.js')}"></script>
+  %endif
 </%block>
 
 <style type="text/css">
@@ -59,6 +62,9 @@ textarea {
       ## Translators: refers to http://git-scm.com/docs/git-log
       <a href="${reverse('gitlogs')}">${_('Git Logs')}</a>
       <a href="${reverse('sysadmin_task_queue')}" class="${modeflag.get('task_queue')}">${_('Task Queue')}</a>
+      %if modeflag.get('mgmt_commands'):
+        <a href="${reverse('sysadmin_mgmt_commands')}" class="${modeflag.get('mgmt_commands')}">${_('MGMT Commands')}</a>
+      %endif
     </h2>
 	<hr />
 %if modeflag.get('users'):
@@ -207,6 +213,12 @@ textarea {
 
 %if msg:
     <p>${msg}</p>
+%endif
+
+%if modeflag.get('mgmt_commands'):
+    <div class="mgmt-commands-body">
+        <h2>Execute Management Command</h2>
+    </div>
 %endif
 
 %if datatable:


### PR DESCRIPTION
This commit creates a 'Mgmt Commands' tab on the sysadmin page. The page
will be pre-populated with a list of four commands:
1. Whitelist a user
2. De-whitelist a user
3. Generate a single certificate
4. Do a certificate run for a course
Additional commands can easily be added to this page by specifying the
command name, keyword arguments, keyword flags, and arguments for the
command in the file lms/static/js/sysadmin/mgmt_commands.js

Tests for this commit have been written and can be run as follows:
python ./manage.py lms test --verbosity=1
lms/djangoapps/dashboard/tests/test_sysadmin_execute_command.py:
TestSysadminExecuteCommand --traceback --settings=test


![sysadmin_mgmt_cmds](https://cloud.githubusercontent.com/assets/1752973/7104381/ce70dc18-e091-11e4-9be6-9182719ba16e.gif)




