### PR TITLE
Hide Print button in PDFJS toolbars

### DIFF
--- a/common/static/css/vendor/pdfjs/viewer.css
+++ b/common/static/css/vendor/pdfjs/viewer.css
@@ -1990,8 +1990,11 @@ html[dir='rtl'] #documentPropertiesOverlay .row > * {
 }
 
 .toolbarButton#openFile,
+.toolbarButton#print,
 .toolbarButton#download,
 .secondaryToolbarButton#secondaryOpenFile,
-.secondaryToolbarButton#secondaryDownload {
+.secondaryToolbarButton#secondaryPrint,
+.secondaryToolbarButton#secondaryDownload,
+.horizontalToolbarSeparator.visibleLargeView {
     display: none;
 }


### PR DESCRIPTION
@stvstnfrd, here's the PR to hide the print button like the other buttons we don't like in PDFJS.

FYI: @Stanford-Online/openedx-courseops 

Edit, here's screenshots of what the change does:

![screen shot 2015-04-20 at 10 54 57 am](https://cloud.githubusercontent.com/assets/3364609/7236778/da903bcc-e74b-11e4-8fc1-a533d1b7a477.png)

![screen shot 2015-04-20 at 10 55 20 am](https://cloud.githubusercontent.com/assets/3364609/7236780/df623b0a-e74b-11e4-8598-fec3f5d28463.png)
