### PR TITLE
Update github.txt to make edx-ora2 to point to newest commit

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -29,7 +29,7 @@
 -e git+https://github.com/edx/bok-choy.git@4a259e3548a19e41cc39433caf68ea58d10a27ba#egg=bok_choy
 -e git+https://github.com/edx-solutions/django-splash.git@7579d052afcf474ece1239153cffe1c89935bc4f#egg=django-splash
 -e git+https://github.com/edx/acid-block.git@df1a7f0cae46567c251d507b8c72168aed8ec042#egg=acid-xblock
--e git+https://github.com/Stanford-Online/edx-ora2.git@79327e593a837546eb6a14a96b30ff4c57570fb3#egg=edx-ora2
+-e git+https://github.com/Stanford-Online/edx-ora2.git@ab3d2d1898c609bac3d7873eec476a5e38a07e2f#egg=edx-ora2
 -e git+https://github.com/edx/opaque-keys.git@0.1.2#egg=opaque-keys
 -e git+https://github.com/edx/ease.git@97de68448e5495385ba043d3091f570a699d5b5f#egg=ease
 -e git+https://github.com/edx/i18n-tools.git@56f048af9b6868613c14aeae760548834c495011#egg=i18n-tools


### PR DESCRIPTION
This commit updates the version of edx-ora2 used by edx-platform. The most recent version fixes the ora2 feedback and comments limit issue. Below is a link to the commit:
https://github.com/Stanford-Online/edx-ora2/commit/96009b84d9054daf3ed06b138f9d772bebe7078a