### PR TITLE
Make adjustments to sysadmin mgmt_commands page

### DIFF
--- a/lms/static/js/sysadmin/mgmt_commands.js
+++ b/lms/static/js/sysadmin/mgmt_commands.js
@@ -35,6 +35,18 @@
             ]
         },
         {
+            'display_name': gettext('View user whitelist'),
+            'method': 'cert_whitelist',
+            'description': gettext('View the list of whitelisted users for a course'),
+            'kwargs': [
+                {
+                    'argument': 'course_id',
+                    'display_name': gettext('course_id'),
+                    'required': true
+                }
+            ]
+        },
+        {
             'display_name': gettext('Generate a single certificate'),
             'method': 'regenerate_user',
             'description': gettext('Put a request on the queue to recreate the certificate for a particular user in a particular course'),
@@ -52,24 +64,12 @@
                 {
                     'argument': 'grade',
                     'display_name': gettext('grade'),
-                    'required': true
+                    'required': false
                 },
                 {
                     'argument': 'template',
                     'display_name': gettext('template'),
-                    'required': true
-                },
-            ]
-        },
-        {
-            'display_name': gettext('Do a certificate run for a course'),
-            'method': 'ungenerated_certs',
-            'description': gettext('Find all students that need certificates for courses that have finished and put their cert requests on the queue.'),
-            'kwargs': [
-                {
-                    'argument': 'course',
-                    'display_name': 'course_id',
-                    'required': true
+                    'required': false
                 },
             ]
         },

--- a/lms/templates/sysadmin_dashboard.html
+++ b/lms/templates/sysadmin_dashboard.html
@@ -62,9 +62,7 @@ textarea {
       ## Translators: refers to http://git-scm.com/docs/git-log
       <a href="${reverse('gitlogs')}">${_('Git Logs')}</a>
       <a href="${reverse('sysadmin_task_queue')}" class="${modeflag.get('task_queue')}">${_('Task Queue')}</a>
-      %if modeflag.get('mgmt_commands'):
-        <a href="${reverse('sysadmin_mgmt_commands')}" class="${modeflag.get('mgmt_commands')}">${_('MGMT Commands')}</a>
-      %endif
+      <a href="${reverse('sysadmin_mgmt_commands')}" class="${modeflag.get('mgmt_commands')}">${_('MGMT Commands')}</a>
     </h2>
 	<hr />
 %if modeflag.get('users'):

--- a/lms/templates/sysadmin_dashboard_gitlogs.html
+++ b/lms/templates/sysadmin_dashboard_gitlogs.html
@@ -63,6 +63,7 @@ textarea {
         ## Translators: refers to http://git-scm.com/docs/git-log
         <a href="${reverse('gitlogs')}" class="active-section">${_('Git Logs')}</a>
         <a href="${reverse('sysadmin_task_queue')}">${_('Task Queue')}</a>
+        <a href="${reverse('sysadmin_mgmt_commands')}">${_('MGMT Commands')}</a>
       </h2>
       <hr />
 


### PR DESCRIPTION
This commit removes the 'Do Certificate Run' command, adds the 'View
user whitelist' command,  adds the mgmt_command tab on the top for
staff users, and  makes the 'template' and 'grade' fields not required
for the 'Generate a Single Certificate' field.