### PR TITLE
Google OpenID scope changes

### DIFF
--- a/common/djangoapps/third_party_auth/provider.py
+++ b/common/djangoapps/third_party_auth/provider.py
@@ -114,6 +114,7 @@ class GoogleOauth2(BaseProvider):
     """Provider for Google's Oauth2 auth system."""
 
     BACKEND_CLASS = google.GoogleOAuth2
+    BACKEND_CLASS.DEFAULT_SCOPE =  ['https://www.googleapis.com/auth/userinfo.email']
     ICON_CLASS = 'icon-google-plus'
     NAME = 'Google'
     SETTINGS = {


### PR DESCRIPTION
Reducing the default scope requested by Google OpenId to just request for email and public profile and not basic profile information. This is in anticipation of turning OpenID on, which is just configuration changes

@stvstnfrd 