### PR TITLE
Adding split mongo fixes back in

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -58,7 +58,7 @@ TEST_DATA_CONTENTSTORE['DOC_STORE_CONFIG']['db'] = 'test_xcontent_%s' % uuid4().
 
 TEST_DATA_DIR = settings.COMMON_TEST_DATA_ROOT
 
-
+@override_settings(DEFAULT_STORE_FOR_NEW_COURSE=None)
 @override_settings(CONTENTSTORE=TEST_DATA_CONTENTSTORE)
 class ContentStoreTestCase(CourseTestCase):
     """
@@ -1058,7 +1058,8 @@ class ContentStoreTest(ContentStoreTestCase):
         except InvalidKeyError:
             # b/c the intent of the test with bad chars isn't to test auth but to test the handler, ignore
             pass
-        resp = self.client.ajax_post('/course/', self.course_data)
+        with mock.patch.dict('django.conf.settings.FEATURES', {"DEFAULT_STORE_FOR_NEW_COURSE": None}):
+            resp = self.client.ajax_post('/course/', self.course_data)
         self.assertEqual(resp.status_code, 200)
         data = parse_json(resp)
         self.assertRegexpMatches(data['ErrMsg'], error_message)
@@ -1069,7 +1070,8 @@ class ContentStoreTest(ContentStoreTestCase):
 
     def test_create_course_duplicate_number(self):
         """Test new course creation - error path"""
-        self.client.ajax_post('/course/', self.course_data)
+        with mock.patch.dict('django.conf.settings.FEATURES', {"DEFAULT_STORE_FOR_NEW_COURSE": None}):
+            self.client.ajax_post('/course/', self.course_data)
         self.course_data['display_name'] = 'Robot Super Course Two'
         self.course_data['run'] = '2013_Summer'
 
@@ -1078,7 +1080,8 @@ class ContentStoreTest(ContentStoreTestCase):
     def test_create_course_case_change(self):
         """Test new course creation - error path due to case insensitive name equality"""
         self.course_data['number'] = 'capital'
-        self.client.ajax_post('/course/', self.course_data)
+        with mock.patch.dict('django.conf.settings.FEATURES', {"DEFAULT_STORE_FOR_NEW_COURSE": None}):
+            self.client.ajax_post('/course/', self.course_data)
         cache_current = self.course_data['org']
         self.course_data['org'] = self.course_data['org'].lower()
         self.assert_course_creation_failed('There is already a course defined with the same organization, course number, and course run. Please change either organization or course number to be unique.')
@@ -1741,12 +1744,13 @@ def _create_course(test, course_key, course_data):
     """
     Creates a course via an AJAX request and verifies the URL returned in the response.
     """
-    course_url = get_url('course_handler', course_key, 'course_key_string')
-    response = test.client.ajax_post(course_url, course_data)
-    test.assertEqual(response.status_code, 200)
-    data = parse_json(response)
-    test.assertNotIn('ErrMsg', data)
-    test.assertEqual(data['url'], course_url)
+    with mock.patch.dict('django.conf.settings.FEATURES', {"DEFAULT_STORE_FOR_NEW_COURSE": None}):
+        course_url = get_url('course_handler', course_key, 'course_key_string')
+        response = test.client.ajax_post(course_url, course_data)
+        test.assertEqual(response.status_code, 200)
+        data = parse_json(response)
+        test.assertNotIn('ErrMsg', data)
+        test.assertEqual(data['url'], course_url)
 
 
 def _get_course_id(course_data, key_class=SlashSeparatedCourseKey):

--- a/cms/djangoapps/contentstore/tests/test_permissions.py
+++ b/cms/djangoapps/contentstore/tests/test_permissions.py
@@ -2,6 +2,7 @@
 Test CRUD for authorization.
 """
 import copy
+import mock
 
 from django.contrib.auth.models import User
 
@@ -30,16 +31,18 @@ class TestCourseAccess(ModuleStoreTestCase):
         self.client.login(username=self.user.username, password=user_password)
 
         # create a course via the view handler which has a different strategy for permissions than the factory
-        self.course_key = SlashSeparatedCourseKey('myu', 'mydept.mycourse', 'myrun')
+        self.course_key = self.store.make_course_key('myu', 'mydept.mycourse', 'myrun')
+
         course_url = reverse_url('course_handler')
-        self.client.ajax_post(course_url,
-            {
-                'org': self.course_key.org,
-                'number': self.course_key.course,
-                'display_name': 'My favorite course',
-                'run': self.course_key.run,
-            }
-        )
+        with mock.patch.dict('django.conf.settings.FEATURES', {"DEFAULT_STORE_FOR_NEW_COURSE": None}):
+            self.client.ajax_post(course_url,
+                {
+                    'org': self.course_key.org,
+                    'number': self.course_key.course,
+                    'display_name': 'My favorite course',
+                    'run': self.course_key.run,
+                }
+            )
 
         self.users = self._create_users()
 

--- a/cms/djangoapps/contentstore/tests/test_users_default_role.py
+++ b/cms/djangoapps/contentstore/tests/test_users_default_role.py
@@ -2,6 +2,7 @@
 Unit tests for checking default forum role "Student" of a user when he creates a course or
 after deleting it creates same course again
 """
+import mock
 from contentstore.tests.utils import AjaxEnabledTestClient
 from contentstore.utils import delete_course_and_groups, reverse_url
 from courseware.tests.factories import UserFactory
@@ -33,15 +34,16 @@ class TestUsersDefaultRole(ModuleStoreTestCase):
         """
         Create course at provided location
         """
-        resp = self.client.ajax_post(
-            reverse_url('course_handler'),
-            {
-                'org': course_key.org,
-                'number': course_key.course,
-                'display_name': 'test course',
-                'run': course_key.run,
-            }
-        )
+        with mock.patch.dict('django.conf.settings.FEATURES', {"DEFAULT_STORE_FOR_NEW_COURSE": None}):
+            resp = self.client.ajax_post(
+                reverse_url('course_handler'),
+                {
+                    'org': course_key.org,
+                    'number': course_key.course,
+                    'display_name': 'test course',
+                    'run': course_key.run,
+                }
+            )
         return resp
 
     def tearDown(self):

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -998,7 +998,7 @@ def _parse_course_id_from_string(input_str):
     """
     m_obj = re.match(r'^/courses/{}'.format(settings.COURSE_ID_PATTERN), input_str)
     if m_obj:
-        return SlashSeparatedCourseKey.from_deprecated_string(m_obj.group('course_id'))
+        return CourseLocator.from_string(m_obj.group('course_id'))
     return None
 
 

--- a/common/lib/xmodule/xmodule/contentstore/content.py
+++ b/common/lib/xmodule/xmodule/contentstore/content.py
@@ -59,6 +59,12 @@ class StaticContent(object):
             asset
         """
         path = path.replace('/', '_')
+        # todo: new coursekeys behave weirdly with assets, will break if title is non ascii
+        # if an asset path is empty (i.e. course image url is empty) split mongo course assets will
+        # throw exceptions. thus we bypass that and just return an empty key
+        if len(path) == 0 and not course_key.deprecated:
+            return ""
+
         return course_key.make_asset_key(
             'asset' if not is_thumbnail else 'thumbnail',
             AssetLocator.clean_keeping_underscores(path)

--- a/lms/djangoapps/courseware/access.py
+++ b/lms/djangoapps/courseware/access.py
@@ -143,7 +143,11 @@ def _has_access_course_desc(user, action, course):
         """
         now = datetime.now(UTC())
         start = course.enrollment_start
+        if start is not None:
+            start = start.replace(tzinfo=pytz.UTC)
         end = course.enrollment_end
+        if end is not None:
+            end = end.replace(tzinfo=pytz.UTC)
 
         return (start is None or now > start) and (end is None or now < end)
 

--- a/lms/djangoapps/instructor/hint_manager.py
+++ b/lms/djangoapps/instructor/hint_manager.py
@@ -91,6 +91,7 @@ def get_hints(request, course_id, field):
     # We want to use the course_id to find all matching usage_id's.
     # To do this, just take the school/number part - leave off the classname.
     # FIXME: we need to figure out how to do this with opaque keys
+    # todo: this will break if we migrate to split
     all_hints = XModuleUserStateSummaryField.objects.filter(
         field_name=field,
         usage_id__regex=re.escape(u'{0.org}/{0.course}'.format(course_id)),

--- a/lms/djangoapps/jabber/utils.py
+++ b/lms/djangoapps/jabber/utils.py
@@ -68,6 +68,8 @@ def get_or_create_password_for_user(username):
 
 def get_room_name_for_course(course_id):
     """
+    This function will break with new-style course_ids from split mongo!
+
     Build a Jabber chat room name given a course ID with format:
 
         <room>@<domain>

--- a/lms/urls.py
+++ b/lms/urls.py
@@ -251,8 +251,7 @@ if settings.COURSEWARE_ENABLED:
         url(r'^change_enrollment$',
             'student.views.change_enrollment', name="change_enrollment"),
         url(r'^change_email_settings$', 'student.views.change_email_settings', name="change_email_settings"),
-
-        url(r'^course_sneakpeek/(?P<course_id>[^/]+/[^/]+/[^/]+)/$',
+        url(r'^course_sneakpeek/{}/$'.format(settings.COURSE_ID_PATTERN),
             'student.views.setup_sneakpeek', name="course_sneakpeek"),
 
         #About the course


### PR DESCRIPTION
Unit tests changes, better url sneak peek pattern matching and returning early when the content path is "" for new courses

merging in after  @stvstnfrd   backports


this does NOT turn on new split functionality for new courses. this just fixes tests and prod functionality for when we do