### PR TITLE
Add Course Tabs Page to Sysadmin Dashboard

### DIFF
--- a/cms/djangoapps/contentstore/management/commands/edit_course_tabs.py
+++ b/cms/djangoapps/contentstore/management/commands/edit_course_tabs.py
@@ -12,7 +12,7 @@ from .prompt import query_yes_no
 
 from courseware.courses import get_course_by_id
 
-from contentstore.views import tabs
+from xmodule.tabs import primitive_insert, primitive_delete
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.locations import SlashSeparatedCourseKey
 from opaque_keys.edx.keys import CourseKey
@@ -24,7 +24,6 @@ def print_course(course):
     print 'num type name'
     for index, item in enumerate(course.tabs):
         print index + 1, '"' + item.get('type') + '"', '"' + item.get('name', '') + '"'
-
 
 # course.tabs looks like this
 # [{u'type': u'courseware'}, {u'type': u'course_info', u'name': u'Course Info'}, {u'type': u'textbooks'},
@@ -84,7 +83,7 @@ command again, adding --insert or --delete to edit the list.
                     raise CommandError(Command.delete_option.help)
                 num = int(args[0])
                 if query_yes_no('Deleting tab {0} Confirm?'.format(num), default='no'):
-                    tabs.primitive_delete(course, num - 1)  # -1 for 0-based indexing
+                    primitive_delete(course, num - 1)  # -1 for 0-based indexing
             elif options['insert']:
                 if len(args) != 3:
                     raise CommandError(Command.insert_option.help)
@@ -92,7 +91,7 @@ command again, adding --insert or --delete to edit the list.
                 tab_type = args[1]
                 name = args[2]
                 if query_yes_no('Inserting tab {0} "{1}" "{2}" Confirm?'.format(num, tab_type, name), default='no'):
-                    tabs.primitive_insert(course, num - 1, tab_type, name)  # -1 as above
+                    primitive_insert(course, num - 1, tab_type, name)  # -1 as above
         except ValueError as e:
             # Cute: translate to CommandError so the CLI error prints nicely.
             raise CommandError(e)

--- a/cms/djangoapps/contentstore/views/tabs.py
+++ b/cms/djangoapps/contentstore/views/tabs.py
@@ -12,7 +12,6 @@ from django_future.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_http_methods
 from edxmako.shortcuts import render_to_response
 from xmodule.modulestore.django import modulestore
-from xmodule.modulestore import ModuleStoreEnum
 from xmodule.tabs import CourseTabList, StaticTab, CourseTab, InvalidTabsException
 from opaque_keys.edx.keys import CourseKey, UsageKey
 
@@ -171,36 +170,3 @@ def get_tab_by_locator(tab_list, usage_key_string):
         url_slug=item.location.name,
     )
     return CourseTabList.get_tab_by_id(tab_list, static_tab.tab_id)
-
-
-# "primitive" tab edit functions driven by the command line.
-# These should be replaced/deleted by a more capable GUI someday.
-# Note that the command line UI identifies the tabs with 1-based
-# indexing, but this implementation code is standard 0-based.
-
-def validate_args(num, tab_type):
-    "Throws for the disallowed cases."
-    if num <= 1:
-        raise ValueError('Tabs 1 and 2 cannot be edited')
-    if tab_type == 'static_tab':
-        raise ValueError('Tabs of type static_tab cannot be edited here (use Studio)')
-
-
-def primitive_delete(course, num):
-    "Deletes the given tab number (0 based)."
-    tabs = course.tabs
-    validate_args(num, tabs[num].get('type', ''))
-    del tabs[num]
-    # Note for future implementations: if you delete a static_tab, then Chris Dodge
-    # points out that there's other stuff to delete beyond this element.
-    # This code happens to not delete static_tab so it doesn't come up.
-    modulestore().update_item(course, ModuleStoreEnum.UserID.primitive_command)
-
-
-def primitive_insert(course, num, tab_type, name):
-    "Inserts a new tab at the given number (0 based)."
-    validate_args(num, tab_type)
-    new_tab = CourseTab.from_json({u'type': unicode(tab_type), u'name': unicode(name)})
-    tabs = course.tabs
-    tabs.insert(num, new_tab)
-    modulestore().update_item(course, ModuleStoreEnum.UserID.primitive_command)

--- a/cms/djangoapps/contentstore/views/tests/test_tabs.py
+++ b/cms/djangoapps/contentstore/views/tests/test_tabs.py
@@ -1,7 +1,7 @@
 """ Tests for tab functions (just primitive). """
 
 import json
-from contentstore.views import tabs
+from xmodule.tabs import primitive_insert, primitive_delete
 from contentstore.tests.utils import CourseTestCase
 from django.test import TestCase
 from xmodule.x_module import STUDENT_VIEW
@@ -199,12 +199,12 @@ class PrimitiveTabEdit(TestCase):
         """Test primitive tab deletion."""
         course = CourseFactory.create()
         with self.assertRaises(ValueError):
-            tabs.primitive_delete(course, 0)
+            primitive_delete(course, 0)
         with self.assertRaises(ValueError):
-            tabs.primitive_delete(course, 1)
+            primitive_delete(course, 1)
         with self.assertRaises(IndexError):
-            tabs.primitive_delete(course, 6)
-        tabs.primitive_delete(course, 2)
+            primitive_delete(course, 6)
+        primitive_delete(course, 2)
         self.assertFalse({u'type': u'textbooks'} in course.tabs)
         # Check that discussion has shifted up
         self.assertEquals(course.tabs[2], {'type': 'discussion', 'name': 'Discussion'})
@@ -212,16 +212,16 @@ class PrimitiveTabEdit(TestCase):
     def test_insert(self):
         """Test primitive tab insertion."""
         course = CourseFactory.create()
-        tabs.primitive_insert(course, 2, 'notes', 'aname')
+        primitive_insert(course, 2, 'notes', 'aname')
         self.assertEquals(course.tabs[2], {'type': 'notes', 'name': 'aname'})
         with self.assertRaises(ValueError):
-            tabs.primitive_insert(course, 0, 'notes', 'aname')
+            primitive_insert(course, 0, 'notes', 'aname')
         with self.assertRaises(ValueError):
-            tabs.primitive_insert(course, 3, 'static_tab', 'aname')
+            primitive_insert(course, 3, 'static_tab', 'aname')
 
     def test_save(self):
         """Test course saving."""
         course = CourseFactory.create()
-        tabs.primitive_insert(course, 3, 'notes', 'aname')
+        primitive_insert(course, 3, 'notes', 'aname')
         course2 = modulestore().get_course(course.id)
         self.assertEquals(course2.tabs[3], {'type': 'notes', 'name': 'aname'})

--- a/common/lib/xmodule/xmodule/tabs.py
+++ b/common/lib/xmodule/xmodule/tabs.py
@@ -9,6 +9,8 @@ Implement CourseTab
 
 from abc import ABCMeta, abstractmethod
 from xblock.fields import List
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore import ModuleStoreEnum
 
 # We should only scrape strings for i18n in this file, since the target language is known only when
 # they are rendered in the template.  So ugettext gets called in the template.
@@ -963,3 +965,32 @@ class UnequalTabsException(Exception):
     A complaint about tab lists being unequal
     """
     pass
+
+
+# Tab functions
+def validate_args(num, tab_type):
+    "Throws for the disallowed cases."
+    if num <= 1:
+        raise ValueError('Tabs 1 and 2 cannot be edited')
+    if tab_type == 'static_tab':
+        raise ValueError('Tabs of type static_tab cannot be edited here (use Studio)')
+
+
+def primitive_delete(course, num):
+    "Deletes the given tab number (0 based)."
+    tabs = course.tabs
+    validate_args(num, tabs[num].get('type', ''))
+    del tabs[num]
+    # Note for future implementations: if you delete a static_tab, then Chris Dodge
+    # points out that there's other stuff to delete beyond this element.
+    # This code happens to not delete static_tab so it doesn't come up.
+    modulestore().update_item(course, ModuleStoreEnum.UserID.primitive_command)
+
+
+def primitive_insert(course, num, tab_type, name):
+    "Inserts a new tab at the given number (0 based)."
+    validate_args(num, tab_type)
+    new_tab = CourseTab.from_json({u'type': unicode(tab_type), u'name': unicode(name)})
+    tabs = course.tabs
+    tabs.insert(num, new_tab)
+    modulestore().update_item(course, ModuleStoreEnum.UserID.primitive_command)

--- a/lms/djangoapps/dashboard/sysadmin_extensions/sysadmin_course_tabs.py
+++ b/lms/djangoapps/dashboard/sysadmin_extensions/sysadmin_course_tabs.py
@@ -1,0 +1,110 @@
+"""Helper module that processes edit_course_tabs requests"""
+from django.utils.translation import ugettext as _
+
+from courseware.courses import get_course_by_id
+from opaque_keys.edx import locator
+from opaque_keys import InvalidKeyError
+from xmodule.tabs import primitive_insert, primitive_delete
+from xmodule.tabs import InvalidTabsException
+
+
+def process_request(action, request):
+    """Routes requests to the appropriate helper function"""
+
+    course_id = request.POST.get('course_id', '').strip()
+    if action == 'get_current_tabs':
+        title = _('Current Tabs:')
+        message = get_current_tabs(course_id)
+    elif action == 'delete_tab':
+        title = _('Delete Tab Status:')
+        delete_tab_args = request.POST.get('tab_delete', '').strip()
+        message = delete_tab(course_id, delete_tab_args)
+    elif action == 'insert_tab':
+        title = _('Insert Tab Status:')
+        insert_tab_args = request.POST.get('tab_insert', '').strip()
+        message = insert_tab(course_id, insert_tab_args)
+    return u"<h4>{title}</h4><p class='unique-row'>{message}</p>".format(
+        title=title,
+        message=message,
+    )
+
+
+def get_current_tabs(course_id):
+    """Displays a list of tabs for the given course"""
+
+    try:
+        course_key = locator.CourseLocator.from_string(course_id)
+        course = get_course_by_id(course_key)
+    except InvalidKeyError:
+        message = _('Error - Invalid Course ID')
+    else:
+        # Translators: number, type, and name refer to tab number, tab type, and tab name
+        message = _('number, type, name')
+        for index, item in enumerate(course.tabs):
+            message += "<br />{tab_number}, {tab_type}, {tab_name}".format(
+                tab_number=index + 1,
+                tab_type=item['type'],
+                tab_name=item['name'],
+            )
+    return message
+
+
+def delete_tab(course_id, args):
+    """Deletes the specified tab from the course"""
+
+    try:
+        tab_number = int(args)
+        course_key = locator.CourseLocator.from_string(course_id)
+        course = get_course_by_id(course_key)
+    except InvalidKeyError:
+        message = _('Error - Invalid Course ID')
+        return message
+    except ValueError:
+        message = _('Error - Invalid arguments. Expecting one argument [tab-number]')
+        return message
+    try:
+        primitive_delete(course, tab_number - 1)  # -1 for 0-based indexing
+        message = _("Tab {tab_number} for course {course_key} successfully deleted".format(
+            tab_number=tab_number,
+            course_key=course_key,
+        ))
+    except ValueError as error:
+        message = _("Command Failed - {msg}".format(
+            msg=error,
+        ))
+    return message
+
+
+def insert_tab(course_id, args):
+    """Inserts the specified tab into the list of tabs for this course"""
+
+    try:
+        course_key = locator.CourseLocator.from_string(course_id)
+        course = get_course_by_id(course_key)
+    except InvalidKeyError:
+        message = _('Error - Invalid Course ID')
+        return message
+    args = [arg.strip() for arg in args.split(",")]
+    if len(args) != 3:
+        message = _('Error - Invalid number of arguments. Expecting [tab-number], [tab-type], [tab-name]')
+        return message
+    try:
+        tab_number = int(args[0])
+        tab_type = args[1]
+        tab_name = args[2]
+    except ValueError:
+        message = _('Error - Invalid arguments. Expecting [tab-number], [tab-type], [tab-name]')
+        return message
+    try:
+        primitive_insert(course, tab_number - 1, tab_type, tab_name)  # -1 as above
+        message = _("Tab {tab_number}, {tab_type}, {tab_name} for course {course_key} successfully created".format(
+            tab_number=tab_number,
+            tab_type=tab_type,
+            tab_name=tab_name,
+            course_key=course_key,
+        ))
+    except (ValueError, InvalidTabsException) as error:
+        message = _("Command Failed - {msg}".format(
+            msg=error,
+        ))
+    return message

--- a/lms/djangoapps/dashboard/sysadmin_urls.py
+++ b/lms/djangoapps/dashboard/sysadmin_urls.py
@@ -11,6 +11,7 @@ urlpatterns = patterns(
     '',
     url(r'^$', sysadmin.Users.as_view(), name="sysadmin"),
     url(r'^courses/?$', sysadmin.Courses.as_view(), name="sysadmin_courses"),
+    url(r'^course_tabs/?$', sysadmin.CourseTabs.as_view(), name="sysadmin_course_tabs"),
     url(r'^staffing/?$', sysadmin.Staffing.as_view(), name="sysadmin_staffing"),
     url(r'^gitlogs/?$', sysadmin.GitLogs.as_view(), name="gitlogs"),
     url(r'^gitlogs/(?P<course_id>.+)$', sysadmin.GitLogs.as_view(),

--- a/lms/djangoapps/dashboard/tests/test_sysadmin.py
+++ b/lms/djangoapps/dashboard/tests/test_sysadmin.py
@@ -68,6 +68,12 @@ class SysadminBaseTestCase(ModuleStoreTestCase):
                                        password='foo')
         self.client = Client()
 
+    def _setsuperuser_login(self):
+        """Makes the test user a superuser and logs them in"""
+        self.user.is_superuser = True
+        self.user.save()
+        self.client.login(username=self.user.username, password='foo')
+
     def _setstaff_login(self):
         """Makes the test user staff and logs them in"""
         GlobalStaff().add_users(self.user)

--- a/lms/djangoapps/dashboard/tests/test_sysadmin_course_tabs.py
+++ b/lms/djangoapps/dashboard/tests/test_sysadmin_course_tabs.py
@@ -1,0 +1,120 @@
+"""Tests for the Edit Course Tabs Feature on the Sysadmin Page"""
+import unittest
+from mock import patch
+
+from django.conf import settings
+from django.core.urlresolvers import reverse
+
+from dashboard.tests.test_sysadmin import SysadminBaseTestCase
+from xmodule.modulestore.tests.factories import CourseFactory
+
+
+@unittest.skipUnless(
+    settings.FEATURES.get('ENABLE_SYSADMIN_DASHBOARD'),
+    'ENABLE_SYSADMIN_DASHBOARD not set',
+)
+class TestSysadminCourseTabs(SysadminBaseTestCase):
+    """Tests all code paths in sysadmin_course_tabs"""
+
+    def setUp(self):
+        super(TestSysadminCourseTabs, self).setUp()
+        self.course = CourseFactory.create()
+        self._setsuperuser_login()
+
+    def test_get_course_tabs_valid_course_id(self):
+        response = self.client.post(reverse('sysadmin_course_tabs'), {
+            'action': 'get_current_tabs',
+            'course_id': unicode(self.course.id),
+        })
+        self.assertIn('number, type, name', response.content.decode('utf-8'))
+
+    def test_get_course_tabs_invalid_course_id(self):
+        response = self.client.post(reverse('sysadmin_course_tabs'), {
+            'action': 'get_current_tabs',
+            'course_id': u'InvalidCourseID',
+        })
+        self.assertIn('Error - Invalid Course ID', response.content.decode('utf-8'))
+
+    def test_delete_tab_valid_course_id(self):
+        response = self.client.post(reverse('sysadmin_course_tabs'), {
+            'action': 'delete_tab',
+            'course_id': unicode(self.course.id),
+            'tab_delete': u'3',
+        })
+        self.assertIn("Tab 3 for course {course_key} successfully deleted".format(
+            course_key=unicode(self.course.id),
+        ), response.content.decode('utf-8'))
+
+    def test_delete_tab_invalid_course_id(self):
+        response = self.client.post(reverse('sysadmin_course_tabs'), {
+            'action': 'delete_tab',
+            'course_id': u'InvalidCourseID',
+            'tab_delete': u'3',
+        })
+        self.assertIn('Error - Invalid Course ID', response.content.decode('utf-8'))
+
+    def test_delete_tab_invalid_args(self):
+        response = self.client.post(reverse('sysadmin_course_tabs'), {
+            'action': 'delete_tab',
+            'course_id': unicode(self.course.id),
+            'tab_delete': u'',
+        })
+        self.assertIn('Error - Invalid arguments. Expecting one argument [tab-number]', response.content.decode('utf-8'))
+
+    def test_delete_tab_throws_exception(self):
+        with patch('dashboard.sysadmin_extensions.sysadmin_course_tabs.primitive_delete') as mock_primitive_delete:
+            mock_primitive_delete.side_effect = ValueError()
+            response = self.client.post(reverse('sysadmin_course_tabs'), {
+                'action': 'delete_tab',
+                'course_id': unicode(self.course.id),
+                'tab_delete': u'3',
+            })
+        self.assertIn("Command Failed - ", response.content.decode('utf-8'))
+
+    def test_insert_tab_valid_course_id(self):
+        response = self.client.post(reverse('sysadmin_course_tabs'), {
+            'action': 'insert_tab',
+            'course_id': unicode(self.course.id),
+            'tab_insert': u'3, progress, Course Progress',
+        })
+        self.assertIn("Tab 3, progress, Course Progress for course {course_key} successfully created".format(
+            course_key=unicode(self.course.id),
+        ), response.content.decode('utf-8'))
+
+    def test_insert_tab_invalid_course_id(self):
+        response = self.client.post(reverse('sysadmin_course_tabs'), {
+            'action': 'insert_tab',
+            'course_id': u'InvalidCourseID',
+            'tab_insert': u'3, progress, Course Progress',
+        })
+        self.assertIn("Error - Invalid Course ID", response.content.decode('utf-8'))
+
+    def test_insert_tab_invalid_number_args(self):
+        response = self.client.post(reverse('sysadmin_course_tabs'), {
+            'action': 'insert_tab',
+            'course_id': unicode(self.course.id),
+            'tab_insert': u'3, progress, Course Progress, extra arg',
+        })
+        self.assertIn("Error - Invalid number of arguments. Expecting [tab-number], [tab-type], [tab-name]".format(
+            course_key=unicode(self.course.id),
+        ), response.content.decode('utf-8'))
+
+    def test_insert_tab_invalid_args(self):
+        response = self.client.post(reverse('sysadmin_course_tabs'), {
+            'action': 'insert_tab',
+            'course_id': unicode(self.course.id),
+            'tab_insert': u'three, progress, Course Progress',
+        })
+        self.assertIn("Error - Invalid arguments. Expecting [tab-number], [tab-type], [tab-name]".format(
+            course_key=unicode(self.course.id),
+        ), response.content.decode('utf-8'))
+
+    def test_insert_tab_throws_exception(self):
+        with patch('dashboard.sysadmin_extensions.sysadmin_course_tabs.primitive_insert') as mock_primitive_insert:
+            mock_primitive_insert.side_effect = ValueError()
+            response = self.client.post(reverse('sysadmin_course_tabs'), {
+                'action': 'insert_tab',
+                'course_id': unicode(self.course.id),
+                'tab_insert': u'3, progress, Course Progress',
+            })
+        self.assertIn('Command Failed - ', response.content.decode('utf-8'))

--- a/lms/djangoapps/dashboard/tests/test_sysadmin_mgmt_commands.py
+++ b/lms/djangoapps/dashboard/tests/test_sysadmin_mgmt_commands.py
@@ -29,12 +29,6 @@ class TestSysadminMgmtCommands(SysadminBaseTestCase):
             'args': ['arg1', 'arg2'],
         }
 
-    def _setsuperuser_login(self):
-        """Makes the test user a superuser and logs them in"""
-        self.user.is_superuser = True
-        self.user.save()
-        self.client.login(username=self.user.username, password='foo')
-
     def test_mgmt_commands_handles_systemexit(self):
         with patch('dashboard.sysadmin.call_command') as call_command:
             call_command.side_effect = SystemExit()

--- a/lms/static/js/sysadmin/course_tabs.js
+++ b/lms/static/js/sysadmin/course_tabs.js
@@ -1,0 +1,23 @@
+(function () {
+    function confirmAndSubmit(e) {
+        var $target = $(e.target);
+        var args = $target.siblings('input').val();
+        var confirmMessage = gettext('Are you sure you want to execute the command: ' + $target.val() + ' with arguments: ' + args + ' ?');
+        if (confirm(confirmMessage)) {
+            var $form = $('.sysadmin-dashboard-wrapper .sysadmin-course-tabs-form');
+            var $hiddenInput = $(document.createElement('input'));
+            $hiddenInput.attr({
+                type: 'hidden',
+                name: 'action'
+            });
+            $hiddenInput.val($target.val());
+            $hiddenInput.appendTo($form);
+            $form.submit();
+        }
+    }
+
+    $(function () {
+        $('.edit-course-tabs .insert-tab-button').click(confirmAndSubmit);
+        $('.edit-course-tabs .delete-tab-button').click(confirmAndSubmit);
+    });
+})();

--- a/lms/static/sass/multicourse/_sysadmin.scss
+++ b/lms/static/sass/multicourse/_sysadmin.scss
@@ -49,3 +49,11 @@
 .mgmt-commands-body .checkbox-label {
     display: inline;
 }
+
+.edit-course-tabs .long-input {
+  width: 60%;
+}
+
+.edit-course-tabs .unique-row {
+  margin-top: 20px;
+}

--- a/lms/templates/sysadmin_dashboard.html
+++ b/lms/templates/sysadmin_dashboard.html
@@ -5,10 +5,14 @@
 
 <%block name="headextra">
   <%static:css group='style-course'/>
+  <link rel="stylesheet" type="text/css" href="${static.url('css/sysadmin.css')}">
   <script type="text/javascript" src="${static.url('js/vendor/flot/jquery.flot.js')}"></script>
   <script type="text/javascript" src="${static.url('js/vendor/flot/jquery.flot.axislabels.js')}"></script>
   %if modeflag.get('mgmt_commands'):
       <script type='text/javascript' src="${static.url('js/sysadmin/mgmt_commands.js')}"></script>
+  %endif
+  %if modeflag.get('course_tabs'):
+    <script type="text/javascript" src="${static.url('js/sysadmin/course_tabs.js')}"></script>
   %endif
 </%block>
 
@@ -58,11 +62,12 @@ textarea {
     <h2 class="instructor-nav">
 	  <a href="${reverse('sysadmin')}" class="${modeflag.get('users')}">${_('Users')}</a>
       <a href="${reverse('sysadmin_courses')}" class="${modeflag.get('courses')}">${_('Courses')}</a>
+      <a href="${reverse('sysadmin_course_tabs')}" class="${modeflag.get('course_tabs')}">${_('Course Tabs')}</a>
       <a href="${reverse('sysadmin_staffing')}" class="${modeflag.get('staffing')}">${_('Staffing and Enrollment')}</a> 
       ## Translators: refers to http://git-scm.com/docs/git-log
       <a href="${reverse('gitlogs')}">${_('Git Logs')}</a>
       <a href="${reverse('sysadmin_task_queue')}" class="${modeflag.get('task_queue')}">${_('Task Queue')}</a>
-      <a href="${reverse('sysadmin_mgmt_commands')}" class="${modeflag.get('mgmt_commands')}">${_('MGMT Commands')}</a>
+      <a href="${reverse('sysadmin_mgmt_commands')}" class="${modeflag.get('mgmt_commands')}">${_('CMDS')}</a>
     </h2>
 	<hr />
 %if modeflag.get('users'):
@@ -142,10 +147,41 @@ textarea {
 
 %endif
 
+%if modeflag.get('course_tabs'):
+<form class="sysadmin-course-tabs-form" name="action" method="POST">
+  <input type="hidden" name="csrfmiddlewaretoken" value="${ csrf_token }" />
+  <div class="edit-course-tabs">
+      <h4>Edit Course Tabs</h4>
+      <ul class="list-input">
+          <li class="field text">
+              <label for="course_id">
+                  ${_('Course ID')}:
+              </label>
+              <input type="text" name="course_id" class="long-input"/>
+          </li>
+      </ul>
+      <div class="form-actions unique-row">
+        <button type="submit" name="action" value="get_current_tabs">${_('Get Current Tabs')}</button>
+      </div>
+      <div class="form-actions unique-row">
+        <button class="delete-tab-button" type="button" value="delete_tab">${_('Delete Tab')}</button>
+        <input type="text" name="tab_delete"/>
+        <span>(sample argument: 7)</span>
+      </div>
+      <div class="form-actions unique-row">
+        <button class="insert-tab-button" type="button" value="insert_tab">${_('Insert Tab')}</button>
+        <input type="text" name="tab_insert"/>
+        <span>(sample arguments: 7, static_tab, Chat)</span>
+      </div>
+  </div>
+</form>
+<hr style="width:40%" />
+%endif
+
 %if modeflag.get('courses'):
 <h3>${_('Administer Courses')}</h3><br/>
 
-<form name="action" method="POST">
+<form class="sysadmin-course-form" name="action" method="POST">
   <input type="hidden" name="csrfmiddlewaretoken" value="${ csrf_token }" />
   <ul class="list-input">
 	<li class="field text">
@@ -210,7 +246,9 @@ textarea {
 %endif
 
 %if msg:
-    <p>${msg}</p>
+    <div class="server-message">
+        <p>${msg}</p>
+    </div>
 %endif
 
 %if modeflag.get('mgmt_commands'):

--- a/lms/templates/sysadmin_dashboard_gitlogs.html
+++ b/lms/templates/sysadmin_dashboard_gitlogs.html
@@ -59,11 +59,12 @@ textarea {
       <h2 class="instructor-nav">
         <a href="${reverse('sysadmin')}">${_('Users')}</a>
         <a href="${reverse('sysadmin_courses')}">${_('Courses')}</a>
+        <a href="${reverse('sysadmin_course_tabs')}">${_('Course Tabs')}</a>
         <a href="${reverse('sysadmin_staffing')}">${_('Staffing and Enrollment')}</a>
         ## Translators: refers to http://git-scm.com/docs/git-log
         <a href="${reverse('gitlogs')}" class="active-section">${_('Git Logs')}</a>
         <a href="${reverse('sysadmin_task_queue')}">${_('Task Queue')}</a>
-        <a href="${reverse('sysadmin_mgmt_commands')}">${_('MGMT Commands')}</a>
+        <a href="${reverse('sysadmin_mgmt_commands')}">${_('CMDS')}</a>
       </h2>
       <hr />
 


### PR DESCRIPTION
This commit adds a 'Course Tabs' tab to the sysadmin dashboard.
The page provides superusers with an interface to support executing
the edit_course_tabs command.

Tests for this tool have been written and can be run
as follows:
python ./manage.py lms test --verbosity=1
lms/djangoapps/dashboard/tests/test_sysadmin_course_tabs.py:TestSysadminCourseTabs
--traceback --settings=test

![edit_course_tabs](https://cloud.githubusercontent.com/assets/1752973/7384666/a7dd2d82-edec-11e4-80b4-cf08bfae6c70.gif)
