### PR TITLE
TinyMCE initialization changes to fix default behavior 

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/html/edit.coffee
+++ b/common/lib/xmodule/xmodule/js/src/html/edit.coffee
@@ -73,6 +73,10 @@ class @HTMLEditingDescriptor
         },
         # Disable visual aid on borderless table.
         visual: false,
+        target_list: [
+          {title: 'New page', value: '_blank'},
+          {title: 'None', value: '_self'},
+        ]
         plugins: "textcolor, link, image, codemirror",
         codemirror: {
           path: "#{baseUrl}/js/vendor"


### PR DESCRIPTION
For opening a link in a new page. Before, it defaulted to "None" but something in the instantiation sets the target incorrectly so it would always open a new page. We switch the default target to new page; if the user sets the target explicitly to None, it will be set correctly.

However there is some problem with the instantiation of TinyMCE because no matter what the default is set as, it always becomes target=[Object] (which opens a new page) so that's why we set is as such. If it is explicitly set, it is set correctly.

![tinymce](https://cloud.githubusercontent.com/assets/461386/7461475/7a74734c-f25f-11e4-8a75-e5e080325479.gif)

https://lagunita.atlassian.net/browse/LE-351

@nthaniel 