### PR TITLE
Add LTI Upload tool to Student Admin page

### DIFF
--- a/lms/djangoapps/instructor/lti_connection.py
+++ b/lms/djangoapps/instructor/lti_connection.py
@@ -1,0 +1,99 @@
+"""
+Send grades to an OpenEdX LTI component
+"""
+import base64
+import hashlib
+import json
+import urllib
+
+from oauthlib.oauth1 import Client  # pylint: disable=F0401
+import requests
+from oauthlib.common import Request
+
+
+def validate_lti_passport(key, secret, url):
+    """
+    Sanity-check LTI passport credentials
+    """
+    response = _send_lti_2_json_request('GET', url, key, secret)
+    return response.status_code == 200
+
+
+def post_grade(url_base, key, secret, grade_row):
+    """
+    Post a grade to the LTI endpoint
+    """
+    uid, anon_id, email, grade, total, comment = grade_row
+
+    if total == 0 or anon_id == '':
+        return (False, uid, email)
+
+    url = url_base + anon_id
+    payload = {
+        '@context': 'http://purl.imsglobal.org/ctx/lis/v2/Result',
+        '@type': 'Result',
+        'comment': comment,
+        'resultScore': grade / total,
+    }
+    response = _send_lti_2_json_request(
+        'PUT',
+        url,
+        key,
+        secret,
+        data=json.dumps(payload),
+    )
+    if response.status_code != 200:
+        return (False, uid, email)
+    else:
+        return (True, uid, email)
+
+
+def _send_lti_2_json_request(method, url, key, secret, data=None):
+    """
+    Issue a session-based LTI request
+    """
+    session = requests.Session()
+    request = requests.Request(method, url, data=data)
+    request.headers.update({
+        'Content-Type': 'application/vnd.ims.lis.v2.result+json',
+    })
+    request_prepared = session.prepare_request(request)
+    auth_header_val = _get_authorization_header(request_prepared, key, secret)
+    request.headers.update({
+        'Authorization': auth_header_val,
+    })
+    request_prepared_authorized = session.prepare_request(request)
+    response = session.send(request_prepared_authorized)
+    return response
+
+
+def _get_authorization_header(request, client_key, client_secret):
+    """
+    Get proper HTTP Authorization header for a given request
+
+    Arguments:
+        request: Request object to log Authorization header for
+
+    Returns:
+        authorization header
+    """
+    sha1 = hashlib.sha1()
+    body = request.body or ''
+    sha1.update(body)
+    oauth_body_hash = unicode(base64.b64encode(
+        sha1.digest()  # pylint: disable=too-many-function-args
+    ))
+    client = Client(client_key, client_secret)
+    params = client.get_oauth_params(None)
+    params.append((u'oauth_body_hash', oauth_body_hash))
+
+    blank_request = Request(urllib.unquote(request.url), http_method=request.method, body='', headers=request.headers, encoding='utf_8')
+    blank_request.oauth_params = params
+    blank_request.decoded_body = ''
+
+    signature = client.get_oauth_signature(blank_request)
+    blank_request.oauth_params.append((u'oauth_signature', signature))
+    headers = client._render(  # pylint: disable=protected-access
+        blank_request
+    )[1]
+    return headers['Authorization']

--- a/lms/djangoapps/instructor/lti_grader.py
+++ b/lms/djangoapps/instructor/lti_grader.py
@@ -1,0 +1,142 @@
+"""
+Send grades to an OpenEdX LTI component
+"""
+import csv
+import tempfile
+
+from django.utils.translation import ugettext as _
+
+from instructor import lti_connection
+
+
+class LTIGrader(object):
+    """
+    Updates grades for a given LTI component
+    """
+
+    def __init__(self, course_id, url_base, lti_key, lti_secret):
+        self.url_base = url_base
+        self.course_id = course_id
+        self.key = lti_key
+        self.secret = lti_secret
+        self.output = {'success': [], 'error': []}
+
+    def _get_first_anon_id(self, grade_data):
+        """
+        Returns the first anonymized student id for in the given uploaded csv data file
+        :param grade_data: an InMemoryUploadedFile with lti grade data
+        :return: anon_id
+        """
+        reader = self._unicode_csv_reader(grade_data)
+        try:
+            # discard the header row
+            reader.next()
+            first_row = reader.next()
+            anon_id = first_row[1]
+            grade_data.seek(0)
+        except StopIteration:
+            self.output['error'].append(_('The CSV file contains no useful data!'))
+            anon_id = None
+        return anon_id
+
+    def update_grades(self, source):
+        """
+        Updates grades for the LTI component with the grade data provided
+        :param grade_data: an InMemoryUploadedFile with lti grade data
+        :return: output, a dictionary with two keys: 'success' and 'error'
+        """
+        grade_data = tempfile.TemporaryFile()
+        for chunk in source.chunks():
+            grade_data.write('\n'.join(chunk.splitlines()))
+        grade_data.seek(0)
+        first_anon_id = self._get_first_anon_id(grade_data)
+        if first_anon_id is None:
+            return self.output
+        test_url = self.url_base + first_anon_id
+        credentials_are_valid = lti_connection.validate_lti_passport(self.key, self.secret, test_url)
+        if not credentials_are_valid:
+            self.output['error'].append(_("LTI passport sanity check failed. Your lti_key ({key}) or lti_secret ({secret}) are probably incorrect.").format(
+                key=self.key,
+                secret=self.secret,
+            ))
+            grade_data.close()
+            return self.output
+
+        for grade_row in self._generate_valid_grading_rows(grade_data):
+            result = lti_connection.post_grade(self.url_base, self.key, self.secret, grade_row)
+            if result[0]:
+                self.output['success'].append(
+                    _("Grade post successful: user id {user_id} (email: {email}).").format(
+                        user_id=result[1],
+                        email=result[2],
+                    )
+                )
+            else:
+                self.output['error'].append(
+                    _("Grade post failed: user id {user_id} (email: {email}).").format(
+                        user_id=result[1],
+                        email=result[2],
+                    )
+                )
+        grade_data.close()
+        return self.output
+
+    def _generate_valid_grading_rows(self, data):
+        """
+        Yield valid grading rows from a file
+        """
+        reader = self._unicode_csv_reader(data)
+        for row_number, row in enumerate(reader):
+
+            #skip the header row
+            if row_number == 0:
+                continue
+
+            if len(row) < 5:
+                self.output['error'].append(_("Bad row: grading_csv row {row_number} ({row}) doesn't have enough info").format(
+                    row_number=row_number,
+                    row=row,
+                ))
+                continue
+            try:
+                if len(row) == 5:
+                    yield tuple([
+                        int(row[0]),
+                        unicode(row[1]),
+                        unicode(row[2]),
+                        float(row[3]),
+                        float(row[4]),
+                        unicode(''),
+                    ])
+                else:
+                    yield tuple([
+                        int(row[0]),
+                        unicode(row[1]),
+                        unicode(row[2]),
+                        float(row[3]),
+                        float(row[4]),
+                        unicode(row[5]),
+                    ])
+            except ValueError:
+                self.output['error'].append(_("Bad row: grading_csv row {row_number} ({row}) has bad values").format(
+                    row_number=row_number,
+                    row=row,
+                ))
+
+    def _unicode_csv_reader(self, unicode_csv_data, dialect=csv.excel, **kwargs):
+        """
+        Yield CSV entries as UTF-8 encoded strings; see https://docs.python.org/2/library/csv.html
+        """
+        # csv.py doesn't do Unicode; encode temporarily as UTF-8:
+        csv_reader = csv.reader(self._utf_8_encoder(unicode_csv_data),
+                                dialect=dialect, **kwargs)
+        for row in csv_reader:
+            # decode UTF-8 back to Unicode, cell by cell:
+            yield [unicode(cell, 'utf-8') for cell in row]
+
+    def _utf_8_encoder(self, unicode_csv_data):
+        """
+        Yield CSV lines as UTF-8 encoded strings; see https://docs.python.org/2/library/csv.html
+        """
+        for line in unicode_csv_data:
+            yield line.encode('utf-8')

--- a/lms/djangoapps/instructor/tests/test_lti_grader.py
+++ b/lms/djangoapps/instructor/tests/test_lti_grader.py
@@ -1,0 +1,102 @@
+"""
+Tests for the Mgmt Commands Feature on the Sysadmin page
+"""
+import unittest
+from mock import patch
+
+from django.conf import settings
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from dashboard.tests.test_sysadmin import SysadminBaseTestCase
+from instructor.lti_grader import LTIGrader
+
+
+@unittest.skipUnless(
+    settings.FEATURES.get('ENABLE_SYSADMIN_DASHBOARD'),
+    'ENABLE_SYSADMIN_DASHBOARD not set',
+)
+class TestLtiGrader(SysadminBaseTestCase):
+    """Tests all code paths in Sysadmin Mgmt Commands"""
+
+    def setUp(self):
+        super(TestLtiGrader, self).setUp()
+        self._setsuperuser_login()
+        self.post_params = {
+            'command': 'fake_command',
+            'key1': 'value1',
+            'key2': 'value2',
+            'kwflags': ['kwflag1', 'kwflag2'],
+            'args': ['arg1', 'arg2'],
+        }
+        self.data = SimpleUploadedFile(
+            'file.csv',
+            'ID,Anonymized User ID,email,grade, max_grade, comments,'
+            '\n1,abcdabcd,abcd@abcd.com,5,10,not bad'
+            '\n2,cdefcdef,cdef@cdef.com,6,10,great'
+        )
+        self.grader = LTIGrader('course_id', 'url_base', 'lti_key', 'lti_secret')
+
+    def test_lti_grader_properly_initialized(self):
+        self.assertEquals('course_id', self.grader.course_id)
+        self.assertEquals('url_base', self.grader.url_base)
+        self.assertEquals('lti_key', self.grader.key)
+        self.assertEquals('lti_secret', self.grader.secret)
+
+    def test_get_first_anon_id(self):
+        first_anon_id = self.grader._get_first_anon_id(self.data)  # pylint: disable=protected-access
+        self.assertEquals(first_anon_id, 'abcdabcd')
+
+    def test_generate_valid_grading_rows(self):
+        valid_rows = self.grader._generate_valid_grading_rows(self.data)  # pylint: disable=protected-access
+        self.assertEquals((1, u'abcdabcd', u'abcd@abcd.com', 5.0, 10.0, u'not bad'), valid_rows.next())
+        self.assertEquals((2, u'cdefcdef', u'cdef@cdef.com', 6.0, 10.0, u'great'), valid_rows.next())
+
+    def test_update_grades_passport_failure(self):
+        def validate_passport_side_effect(key, secret, test_url):  # pylint: disable=unused-argument
+            """
+            Side effect designed to replace validate_lti_passport in lti_connection.py, mocking validation failure
+            """
+            return False
+        with patch('instructor.lti_grader.lti_connection') as mock_lti_connection:
+            mock_lti_connection.validate_lti_passport.side_effect = validate_passport_side_effect
+            actual_output = self.grader.update_grades(self.data)['error']
+            expected_output = ['LTI passport sanity check failed. Your lti_key (lti_key) or lti_secret (lti_secret) are probably incorrect.']
+            self.assertEquals(expected_output, actual_output)
+
+    def test_update_grades_success(self):
+        def validate_passport_side_effect(key, secret, test_url):  # pylint: disable=unused-argument
+            """
+            Side effect designed to replace validate_lti_passport in lti_connection.py, mocking validation success
+            """
+            return True
+
+        def post_success_side_effect(url_base, key, secret, grade_row):  # pylint: disable=unused-argument
+            """
+            Side effect designed to replace post_grade in lti_connection.py, mocking successful grade post
+            """
+            return (True, grade_row[0], grade_row[2])
+        with patch('instructor.lti_grader.lti_connection') as mock_lti_connection:
+            mock_lti_connection.validate_lti_passport.side_effect = validate_passport_side_effect
+            mock_lti_connection.post_grade.side_effect = post_success_side_effect
+            actual_output = self.grader.update_grades(self.data)['success']
+            expected_output = ['Grade post successful: user id 1 (email: abcd@abcd.com).', 'Grade post successful: user id 2 (email: cdef@cdef.com).']
+            self.assertEquals(expected_output, actual_output)
+
+    def test_update_grades_failure(self):
+        def validate_passport_side_effect(key, secret, test_url):  # pylint: disable=unused-argument
+            """
+            Side effect designed to replace validate_lti_passport in lti_connection.py, mocking validation success
+            """
+            return True
+
+        def post_failure_side_effect(url_base, key, secret, grade_row):  # pylint: disable=unused-argument
+            """
+            Side effect designed to replace post_grade in lti_connection.py, mocking unsuccessful grade post
+            """
+            return (False, grade_row[0], grade_row[2])
+        with patch('instructor.lti_grader.lti_connection') as mock_lti_connection:
+            mock_lti_connection.validate_lti_passport.side_effect = validate_passport_side_effect
+            mock_lti_connection.post_grade.side_effect = post_failure_side_effect
+            actual_output = self.grader.update_grades(self.data)['error']
+            expected_output = ['Grade post failed: user id 1 (email: abcd@abcd.com).', 'Grade post failed: user id 2 (email: cdef@cdef.com).']
+            self.assertEquals(expected_output, actual_output)

--- a/lms/djangoapps/instructor/views/api.py
+++ b/lms/djangoapps/instructor/views/api.py
@@ -30,6 +30,7 @@ import urllib
 import urllib2
 from util.json_request import JsonResponse
 from instructor.views.instructor_task_helpers import extract_email_features, extract_task_features
+from instructor_analytics.csvs import create_csv_response
 import gzip
 
 from microsite_configuration import microsite
@@ -67,6 +68,7 @@ import instructor_analytics.csvs
 import csv
 from user_api.models import UserPreference
 from instructor.views import INVOICE_KEY
+from instructor.lti_grader import LTIGrader
 
 from submissions import api as sub_api  # installed from the edx-submissions repository
 
@@ -2580,6 +2582,48 @@ def spoc_gradebook(request, course_id):
         'staff_access': True,
         'ordered_grades': sorted(course.grade_cutoffs.items(), key=lambda i: i[1], reverse=True),
     })
+
+
+@ensure_csrf_cookie
+@cache_control(no_cache=True, no_store=True, must_revalidate=True)
+@require_level('staff')
+def get_blank_lti(request, course_id):  # pylint: disable=unused-argument
+    """
+    Respond with 4-column CSV output of ID, email, grade (blank), max_grade (blank), and comments (blank)
+    """
+    course_id = CourseKey.from_string(course_id)
+    students = User.objects.filter(
+        courseenrollment__course_id=course_id,
+    ).order_by('id')
+    header = ['ID', 'Anonymized User ID', 'email', 'grade', 'max_grade', 'comments']
+    encoded_header = [unicode(s).encode('utf-8') for s in header]
+    rows = [[s.id, unique_id_for_user(s, save=False), s.email, '', '', ''] for s in students]
+    csv_filename = "{course_id}-blank-grade-submission.csv".format(
+        course_id=unicode(course_id).replace('/', '-'),
+    )
+    return create_csv_response(csv_filename, encoded_header, rows)
+
+
+@ensure_csrf_cookie
+@cache_control(no_cache=True, no_store=True, must_revalidate=True)
+@require_level('staff')
+def upload_lti(request, course_id):
+    """
+    Update grades for the lti component specified by processing the uploaded csv file
+    :param request: The post request containing lti-key, lti-secret, and the lti-grades data file
+    :param course_id: the id of the course containing the lti component
+    :return: JsonResponse with the status from the LTIGrader
+    """
+    lti_base_url = re.sub(
+        r'\{anon_user_id\}',
+        '',
+        request.POST.get('lti-endpoint')
+    )
+    lti_key = request.POST.get('lti-key')
+    lti_secret = request.POST.get('lti-secret')
+    lti_grader = LTIGrader(course_id, lti_base_url, lti_key, lti_secret)
+    status = lti_grader.update_grades(request.FILES['lti-grades'])
+    return JsonResponse({'status': status})
 
 
 @ensure_csrf_cookie

--- a/lms/djangoapps/instructor/views/api_urls.py
+++ b/lms/djangoapps/instructor/views/api_urls.py
@@ -118,6 +118,20 @@ urlpatterns = patterns('',  # nopep8
     url(r'^gradebook$',
         'instructor.views.api.spoc_gradebook', name='spoc_gradebook'),
 
+    # Blank LTI csv
+    url(
+        r'^get_blank_lti$',
+        'instructor.views.api.get_blank_lti',
+        name='get_blank_lti',
+    ),
+
+    # Upload LTI csv
+    url(
+        r'^upload_lti$',
+        'instructor.views.api.upload_lti',
+        name='upload_lti',
+    ),
+
     # Collect student forums data
     url(r'get_student_forums_usage',
         'instructor.views.api.get_student_forums_usage', name='get_student_forums_usage'),

--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -310,6 +310,8 @@ def _section_student_admin(course, access):
         'rescore_problem_url': reverse('rescore_problem', kwargs={'course_id': course_key.to_deprecated_string()}),
         'list_instructor_tasks_url': reverse('list_instructor_tasks', kwargs={'course_id': course_key.to_deprecated_string()}),
         'spoc_gradebook_url': reverse('spoc_gradebook', kwargs={'course_id': course_key.to_deprecated_string()}),
+        'get_blank_lti_url': reverse('get_blank_lti', kwargs={'course_id': course_key.to_deprecated_string()}),
+        'upload_lti_url': reverse('upload_lti', kwargs={'course_id': unicode(course_key)}),
     }
     return section_data
 

--- a/lms/static/coffee/src/instructor_dashboard/student_admin.coffee
+++ b/lms/static/coffee/src/instructor_dashboard/student_admin.coffee
@@ -47,6 +47,7 @@ class StudentAdmin
     @$btn_rescore_problem_all     = @$section.find "input[name='rescore-problem-all']"
     @$btn_task_history_all        = @$section.find "input[name='task-history-all']"
     @$table_task_history_all      = @$section.find ".task-history-all-table"
+    @$btn_download_blank_lti      = @$section.find "input[name='lti-blank-grades']"
     @instructor_tasks             = new (PendingInstructorTasks()) @$section
 
     # response areas
@@ -72,6 +73,10 @@ class StudentAdmin
         success: @clear_errors_then (data) ->
           window.location = data.progress_url
         error: std_ajax_err => @$request_response_error_progress.text full_error_message
+
+    @$btn_download_blank_lti.click (e) =>
+      url = @$btn_download_blank_lti.data 'endpoint'
+      location.href = url
 
     # reset attempts for student on problem
     @$btn_reset_attempts_single.click =>

--- a/lms/static/js/instructor/lti_uploads.js
+++ b/lms/static/js/instructor/lti_uploads.js
@@ -1,0 +1,114 @@
+(function (){
+    function progressHandlingFunction(event){
+        if(event.lengthComputable){
+            var percent = parseInt(event.loaded / event.total * 100, 10);
+            $('.upload').text('Uploading... ' + percent + '%');
+        }
+    }
+    function beforeSendHandler(){
+        var outputBox = $('.output-box');
+        outputBox.children('.loading').text('Loading...');
+        var successBox = outputBox.children('.success').find('p');
+        var errorBox = outputBox.children('.error').find('p');
+        successBox.html('');
+        errorBox.html('');
+    }
+    function reloadUploader(){
+        var uploadDiv = $('.upload');
+        var fileUploadElement = $(document.createElement('input'));
+        fileUploadElement.addClass('fileupload');
+        fileUploadElement.attr({
+            'name': 'lti-grades',
+            'type': 'file',
+            'accept': '.csv'
+        });
+        var selectButton = $(document.createElement('button'));
+        selectButton.addClass('select-file-button');
+        selectButton.text('Select a file');
+        selectButton.click(function(event){event.preventDefault();});
+        uploadDiv.html(fileUploadElement);
+        uploadDiv.append(selectButton);
+        fileUploadElement.change(updateFileField);
+    }
+    function completeHandler(response){
+        var outputBox = $('.output-box');
+        var successBox = outputBox.children('.success').find('ul');
+        var errorBox = outputBox.children('.error').find('ul');
+        outputBox.children('.loading').text('');
+        successBox.html('');
+        errorBox.html('');
+        $.each(response.status.success, function (index, row){
+            var li_elt = $(document.createElement('li'));
+            li_elt.append(row);
+            successBox.append(li_elt);
+        });
+        $.each(response.status.error, function (index, row){
+            var li_elt = $(document.createElement('li'));
+            li_elt.append(row);
+            errorBox.append(li_elt);
+        });
+        reloadUploader();
+    }
+    function upload_lti(event){
+        $form = $(event.target).closest('form');
+        var formData = new FormData($form[0]);
+        $.ajax({
+            url: $form.attr('action'),  //Server script to process data
+            type: 'POST',
+            xhr: function() {  // Custom XMLHttpRequest
+                var myXhr = $.ajaxSettings.xhr();
+                if(myXhr.upload){ // Check if upload property exists
+                    myXhr.upload.addEventListener('progress', progressHandlingFunction, false); // For handling the progress of the upload
+                }
+                return myXhr;
+            },
+            //Ajax events
+            beforeSend: beforeSendHandler,
+            success: completeHandler,
+            // Form data
+            data: formData,
+            //Options to tell jQuery not to process data or worry about content-type.
+            cache: false,
+            contentType: false,
+            processData: false
+        });
+    }
+    function load_lti_endpoints(){
+        function compare_endpoints(a, b){
+            if (a.display_name < b.display_name) return -1;
+            if (a.display_name > b.display_name) return 1;
+            return 0;
+        }
+        $.ajax({
+            url: 'lti_rest_endpoints/',
+            type: 'GET',
+            dataType: 'json',
+            context: this,
+            success: function(endpoints) {
+                endpoints.sort(compare_endpoints);
+                for (var i = 0; i < endpoints.length; i++){
+                    var $option = $(document.createElement('option'));
+                    $option.val(endpoints[i].lti_2_0_result_service_json_endpoint);
+                    $option.text(endpoints[i].display_name);
+                    $option.appendTo($('.endpoint-selector'));
+                }
+            },
+            error: null
+        });
+    }
+    function updateFileField(event){
+        var $filefield = $(event.target);
+        var $select_file_button = $filefield.siblings('.select-file-button');
+        if ($filefield.val()){
+            $filefield.css('z-index', '1');
+            $select_file_button.css('z-index', '2');
+            var filename = $filefield.val().replace(/^.*[\\\/]/, '');
+            $select_file_button.text('Upload ' + filename)
+            $select_file_button.click(upload_lti);
+        }
+    }
+    $(function(){
+        load_lti_endpoints();
+        reloadUploader();
+    });
+})();

--- a/lms/static/sass/course/instructor/_instructor_2.scss
+++ b/lms/static/sass/course/instructor/_instructor_2.scss
@@ -1979,3 +1979,66 @@ input[name="subject"] {
   left: 2em;
   right: auto;
 }
+
+.course-specific-container {
+
+  .upload {
+    position: relative;
+
+    button {
+      position: absolute;
+      top: 0;
+      left: 0;
+      z-index: 1;
+    }
+
+    .fileupload {
+      position: relative;
+      z-index: 2;
+      opacity: 0;
+      height: ($baseline*1.5);
+      width: ($baseline*6);
+    }
+  }
+
+  .bordered-fieldset {
+    border: solid 4px #000000;
+    padding: $baseline;
+    margin-top: ($baseline*1.5);
+  }
+
+  .success, .error {
+    ul {
+      list-style-type: none;
+
+      li {
+        margin-bottom: ($baseline*0.5);
+      }
+    }
+  }
+
+  .error {
+    color: #E40004;
+  }
+
+  .success {
+    color: #008000;
+  }
+
+  .new-section {
+    margin-top: $baseline;
+  }
+
+  .select-tag {
+    width: 40%;
+    height: ($baseline*1.5);
+    font-size: 1.1em;
+  }
+
+  .output-box {
+    .loading {
+      font-size: 2em;
+      margin-bottom: $baseline;
+    }
+  }
+}

--- a/lms/templates/instructor/instructor_dashboard_2/student_admin.html
+++ b/lms/templates/instructor/instructor_dashboard_2/student_admin.html
@@ -1,4 +1,5 @@
 <%! from django.utils.translation import ugettext as _ %>
+<%namespace name='static' file='/static_content.html'/>
 <%page args="section_data"/>
 
 <div>
@@ -111,6 +112,47 @@
       <div class="task-history-all-table"></div>
     </p>
   </div>
+%endif
+
+%if section_data['access']['instructor']:
+  <hr>
+  <div class='course-specific-container action-type-container'>
+    <h2>${_("Submit External Grades")}</h2>
+    <p>
+      ${_("To import grades from an assignment outside of the Lagunita platform, "
+      "ask the Course Operations team to set up external grading for your course. "
+      "Then download the grade submission CSV with the button below and fill in the missing fields. "
+      "Once you have saved your changes, select an assignment you are importing from the drop-down. "
+      "Finally, upload and submit your grades.")}
+    </p>
+    <p><input type='button' name='lti-blank-grades' value="${_("Download Blank Grade Submission CSV")}" data-csv='true' class='csv' data-endpoint="${ section_data['get_blank_lti_url'] }"></p>
+    <form id='lti-upload-form' method='post' action="${ section_data['upload_lti_url'] }" enctype='multipart/form-data'>
+      <h4 class='new-section'>${_("Select Assignment")}</h4>
+      <select class='endpoint-selector select-tag new-section' name='lti-endpoint'></select>
+      <div class='new-section'>
+        <label for='lti-key'>${_("LTI Key")}</label>
+        <input type='text' name='lti-key'>
+        <label for='lti-secret'>${_("LTI Secret")}</label>
+        <input type='text' name='lti-secret'>
+      </div>
+      <h4 class='new-section'>${_("Upload Revised Grade CSV")}</h4>
+      <div class='upload new-section'></div>
+      <input type='hidden' name='csrfmiddlewaretoken' value="${ csrf_token }">
+      <fieldset class='bordered-fieldset output-box'>
+        <legend>${_("Upload Status")}</legend>
+        <div class='loading'></div>
+        <div class='error'>
+          <h3 class='error'>${_("Error:")}</h3>
+          <ul class='error'></ul>
+        </div>
+        <div class='success new-section'>
+          <h3 class='success'>${_("Success:")}</h3>
+          <ul class='success'></ul>
+        </div>
+      </fieldset>
+    </form>
+  </div>
+  <script type='text/javascript' src="${static.url('js/instructor/lti_uploads.js')}"></script>
 %endif
 
 %if settings.FEATURES.get('ENABLE_INSTRUCTOR_BACKGROUND_TASKS'):


### PR DESCRIPTION
Currently, uploading a grade spreadsheet via LTI 2.0 involves sending the spreadsheet
to courseops, who runs a python script locally to do the work. This commit adds component
to the 'Student Admin' section of the instructor dashboard, enabling instructors to download
a blank spreadsheet to grade all students in their course. Once they have entered grades for
all students, instructors are be able to upload this spreadsheet (with grades) so that
the grades take effect for a specific LTI component they intend to update. A visual example
of the upload process is provided below.

A test suite for this commit has been written and can be run as follows:
python ./manage.py lms test --verbosity=1
lms/djangoapps/instructor/tests/test_lti_grader.py:TestLtiGrader
--traceback --settings=test

![lti_gif](https://cloud.githubusercontent.com/assets/1752973/7760951/2f5c1dd2-ffd5-11e4-9378-c2452ef4f0aa.gif)
