### PR TITLE
Bugfix - Make fields work for Single User Certs

### DIFF
--- a/lms/static/js/sysadmin/mgmt_commands.js
+++ b/lms/static/js/sysadmin/mgmt_commands.js
@@ -62,12 +62,12 @@
                     'required': true
                 },
                 {
-                    'argument': 'grade',
+                    'argument': 'grade_value',
                     'display_name': gettext('grade'),
                     'required': false
                 },
                 {
-                    'argument': 'template',
+                    'argument': 'template_file',
                     'display_name': gettext('template'),
                     'required': false
                 },


### PR DESCRIPTION
This commit fixes the bug reported in Jira ticket
LE-423. The bug was caused because the name of the grade
keword differed from the keyword being used when handling
input from the user. This commit fixes this isue.