### PR TITLE
Make non-required mgmt cmd arguments optional

### DIFF
--- a/lms/static/js/sysadmin/mgmt_commands.js
+++ b/lms/static/js/sysadmin/mgmt_commands.js
@@ -88,14 +88,19 @@
     }
 
     function submitForm(event){
+
+        var form = $('#command-form');
+        var form_data = form.clone();
+        form_data.find('input:not([required])').filter(function() {
+            return $(this).val() === '';
+        }).remove();
         var button = $(event.target);
         button.prop('disabled',true);
-        var form = $('#command-form');
 
         $.ajax({
             url: '/sysadmin/mgmt_commands/',
             type: 'POST',
-            data: form.serialize(),
+            data: form_data.serialize(),
             dataType: 'json',
             success: function(data) {
 
@@ -129,11 +134,13 @@
         $inputRow.addClass('form-actions')
         var label = $(document.createElement('label'));
         label.html(arg.display_name);
+        var input = $(document.createElement('input'));
+
         if (arg.required){
-            label.append('<span>*</span>')
+            label.append('*');
+            input.prop('required', true);
         }
 
-        var input = $(document.createElement('input'));
 
         if (type == 'kwarg'){
 


### PR DESCRIPTION
This commit adds to the logic of how management commands
are run from the sysadmin panel. Specifically, if arguments
or keywords are not required then they are simply not included
in the command if the user leaves the field blank. This applies
to both keyword arguments or actual arguments.