### PR TITLE
Change column name from points to votes in Student Forums Report

### DIFF
--- a/lms/djangoapps/instructor/utils.py
+++ b/lms/djangoapps/instructor/utils.py
@@ -319,10 +319,10 @@ def collect_student_forums_data(course_id):
         [
             result['_id'],
             result['posts'],
-            result['points'],
+            result['votes'],
         ] for result in results
     ]
-    header = ['Username', 'Posts', 'Points']
+    header = ['Username', 'Posts', 'Votes']
     return header, parsed_results
 
 
@@ -344,7 +344,7 @@ def generate_student_forums_query(course_id):
             "$group": {
                 "_id": "$author_username",
                 "posts": {"$sum": 1},
-                "points": {"$sum": "$votes.point"}
+                "votes": {"$sum": "$votes.point"}
             }
         },
     ]

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -367,7 +367,7 @@ class TestInstructorStudentForumsReport(TestReportMixin, InstructorTaskCourseTes
         start_time = datetime.now(UTC)
         mock_time.now.return_value = start_time
 
-        test_header = ['Username', 'Posts', 'Points']
+        test_header = ['Username', 'Posts', 'Votes']
         test_rows = [['row1_field1', 'row1_field2', 'row1_field3'], ['row2_field1', 'row2_field2', 'row2_field3']]
 
         with patch('instructor_task.tasks_helper._get_current_task') as mock_current_task:


### PR DESCRIPTION
Since the term points is ambiguous and actually refers to the number of aggregate votes received by a user, this commit modifies "points" to say "votes" in the student forums report.