### PR TITLE
Hide progress summary behind a feature flag

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -394,6 +394,8 @@ FEATURES = {
         'TWITTER_SHARING': False,
         'TWITTER_SHARING_TEXT': None
     },
+
+    'ENABLE_PROGRESS_SUMMARY': True,
 }
 
 # Ignore static asset files on import which match this pattern

--- a/lms/static/sass/course/_profile.scss
+++ b/lms/static/sass/course/_profile.scss
@@ -130,6 +130,15 @@
     }
   }
 
+  #course-info-progress {
+    .progress-info-mouseover {
+      padding: 15px;
+      margin: 15px 0;
+      border: 1px dashed #CCC;
+      background-color: #EEE;
+    }
+  }
+
   .course-info {
     @extend .content;
 

--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -52,6 +52,13 @@ from django.utils.http import urlquote_plus
         <h1 class="progress-certificates-title">${_("Course Progress for Student '{username}' ({email})").format(username=student.username, email=student.email)}</h1>
       </header>
 
+      <section class="progress-info-mouseover">
+        <p>
+            Note: Submitted assignments will appear as bars in the Progress chart.
+            Mouse over a bar to see more information about the relevant assignment.
+        </p>
+      </section>
+
         %if show_generate_cert_btn:
         <div class="wrapper-msg wrapper-auto-cert">
             <div id="errors-info" class="errors-info"></div>
@@ -94,6 +101,7 @@ from django.utils.http import urlquote_plus
         <div class="grade-detail-graph" id="grade-detail-graph" aria-hidden="true"></div>
       %endif
 
+      %if settings.FEATURES['ENABLE_PROGRESS_SUMMARY']:
       <div class="chapters">
         %for chapter in courseware_summary:
         %if not chapter['display_name'] == "hidden":
@@ -156,6 +164,7 @@ from django.utils.http import urlquote_plus
         %endif
         %endfor
       </div> <!--End chapters-->
+      %endif
 
     </div>
   </div>


### PR DESCRIPTION
Following the recent merge from upstream, we noticed severe performance
degradation on the progress page. Across the board, we see roughly an 8x
increase (!?) in page load times (HTML generation only).

As the issue wasn't caused directly by the progress page, but rather by
deeper library/course changes, alleviating the slow load times would
require significant rearchitecting.

Since much of the degradation is caused by the summary, as opposed to
the chart, this will allow us to toggle off the summary section as a
stop-gap measure.

For future work, we may look to split out the progress summary onto its
own page, though we won't pursue that at this time.

EdX is aware of the performance issue [1], as they experience it as well.
The issue appears to have surfaced in late November.

[1] https://openedx.atlassian.net/browse/TNL-905