### PR TITLE
Use string representation for dates

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -862,8 +862,8 @@ def send_test_enrollment_email(request, course_key_string):
         'name': user.profile.name,
         'course_title': course.display_name,
         'course_id': course_key,
-        'course_start_date': course.start,
-        'course_end_date': course.end,
+        'course_start_date': get_default_time_display(course.start),
+        'course_end_date': get_default_time_display(course.end),
     }
     message = substitute_keywords_with_data(message, context)
 

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -96,6 +96,7 @@ import track.views
 
 import dogstats_wrapper as dog_stats_api
 
+from util.date_utils import get_default_time_display
 from util.db import commit_on_success_with_read_committed
 from util.json_request import JsonResponse
 from util.bad_request_rate_limiter import BadRequestRateLimiter
@@ -1023,8 +1024,8 @@ def notify_enrollment_by_email(course, user, request):
                 'name': user.profile.name,
                 'course_title': course.display_name,
                 'course_id': course.id,
-                'course_start_date': course.start,
-                'course_end_date': course.end,
+                'course_start_date': get_default_time_display(course.start),
+                'course_end_date': get_default_time_display(course.end),
             }
             message = substitute_keywords_with_data(message, context)
             user.email_user(subject, message, from_address)

--- a/common/djangoapps/util/keyword_substitution.py
+++ b/common/djangoapps/util/keyword_substitution.py
@@ -29,7 +29,6 @@ from collections import namedtuple
 
 from django.contrib.auth.models import User
 from student.models import anonymous_id_for_user
-from date_utils import get_default_time_display
 
 Keyword = namedtuple('Keyword', 'func desc')
 
@@ -52,11 +51,11 @@ KEYWORD_FUNCTION_MAP = {
         'course identifier'
     ),
     '%%COURSE_START_DATE%%': Keyword(
-        lambda context: get_default_time_display(context.get('course_start_date')),
+        lambda context: context.get('course_start_date'),
         'start date of the course'
     ),
     '%%COURSE_END_DATE%%': Keyword(
-        lambda context: get_default_time_display(context.get('course_end_date')),
+        lambda context: context.get('course_end_date'),
         'end date of the course'
     ),
 }

--- a/common/djangoapps/util/tests/test_keyword_sub_utils.py
+++ b/common/djangoapps/util/tests/test_keyword_sub_utils.py
@@ -9,6 +9,7 @@ from ddt import ddt, file_data
 from mock import patch
 
 
+from util.date_utils import get_default_time_display
 from util import keyword_substitution as Ks
 
 
@@ -33,7 +34,7 @@ class KeywordSubTest(ModuleStoreTestCase):
             'user_id': self.user.id,
             'course_title': self.course.display_name,
             'name': self.user.profile.name,
-            'course_end_date': self.course.end,
+            'course_end_date': get_default_time_display(self.course.end),
         }
 
     @file_data('fixtures/test_keyword_coursename_sub.json')

--- a/common/lib/xmodule/xmodule/html_module.py
+++ b/common/lib/xmodule/xmodule/html_module.py
@@ -10,6 +10,8 @@ from path import path
 from fs.errors import ResourceNotFoundError
 from pkg_resources import resource_string
 
+from util.date_utils import get_default_time_display
+
 import dogstats_wrapper as dog_stats_api
 from xmodule.annotator_mixin import html_to_text
 from xmodule.contentstore.content import StaticContent
@@ -83,8 +85,8 @@ class HtmlModuleMixin(HtmlFields, XModule):
                 'name': user.profile.name if user else '',
                 'course_title': course.display_name,
                 'course_id': self.course_id,
-                'course_start_date': course.start,
-                'course_end_date': course.end,
+                'course_start_date': get_default_time_display(course.start),
+                'course_end_date': get_default_time_display(course.end),
             }
             return self.system.substitute_keywords_with_data(self.data, context)
         return self.data

--- a/common/lib/xmodule/xmodule/tests/test_html_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_html_module.py
@@ -1,6 +1,6 @@
 import unittest
 
-from mock import Mock
+from mock import Mock, patch
 
 from xblock.field_data import DictFieldData
 from xmodule.html_module import HtmlModule, HtmlDescriptor
@@ -35,7 +35,9 @@ class HtmlModuleSubstitutionTestCase(unittest.TestCase):
         module_system = get_test_system()
         module_system.substitute_keywords_with_data = Mock(return_value=anon_id)
         module = HtmlModule(self.descriptor, module_system, field_data, Mock())
-        self.assertEqual(module.get_html(), anon_id)
+        with patch('xmodule.html_module.get_default_time_display') as mock_get_default_time_display:
+            mock_get_default_time_display.return_value = u''
+            self.assertEqual(module.get_html(), anon_id)
 
 
 class HtmlDescriptorIndexingTestCase(unittest.TestCase):

--- a/lms/djangoapps/bulk_email/tasks.py
+++ b/lms/djangoapps/bulk_email/tasks.py
@@ -50,6 +50,7 @@ from instructor_task.subtasks import (
     update_subtask_status,
 )
 from util.query import use_read_replica_if_available
+from util.date_utils import get_default_time_display
 
 log = logging.getLogger('edx.celery.task')
 
@@ -165,8 +166,8 @@ def _get_course_email_context(course):
         'course_title': course_title,
         'course_url': course_url,
         'course_image_url': image_url,
-        'course_start_date': course.start,
-        'course_end_date': course.end,
+        'course_start_date': get_default_time_display(course.start),
+        'course_end_date': get_default_time_display(course.end),
         'account_settings_url': 'https://{}{}'.format(settings.SITE_NAME, reverse('dashboard')),
         'platform_name': settings.PLATFORM_NAME,
     }

--- a/lms/djangoapps/courseware/courses.py
+++ b/lms/djangoapps/courseware/courses.py
@@ -17,6 +17,7 @@ from static_replace import replace_static_urls
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.x_module import STUDENT_VIEW
 from microsite_configuration import microsite
+from util.date_utils import get_default_time_display
 from util.keyword_substitution import substitute_keywords_with_data
 
 from courseware.access import has_access
@@ -297,8 +298,8 @@ def get_course_info_section(request, course, section_key):
                 'name': request.user.profile.name,
                 'course_title': course.display_name,
                 'course_id': course.id,
-                'course_start_date': course.start,
-                'course_end_date': course.end,
+                'course_start_date': get_default_time_display(course.start),
+                'course_end_date': get_default_time_display(course.end),
             }
             html = substitute_keywords_with_data(html, context)
         except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
Pass dates as string for all contexts needed for keyword sub.
Fixes bulk email which can't serialize dates to JSON for celery.

@stvstnfrd  this subsumes #320 
This would impact merging release back to master right?