### PR TITLE
Fix of video seek bug.

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/06_video_progress_slider.js
+++ b/common/lib/xmodule/xmodule/js/src/video/06_video_progress_slider.js
@@ -170,10 +170,6 @@ function () {
             endTime = Math.min(this.config.endTime, endTime);
         }
 
-        if (this.config.endTime !== null) {
-            duration = Math.min(this.config.endTime, duration);
-        }
-
         this.videoProgressSlider.frozen = true;
 
         // Remember the seek to value so that we don't repeat ourselves on the


### PR DESCRIPTION
Bug introduced in last merge caused the video seek widget to
become incapacitated when a video end time was set.