### PR TITLE
Add missing comma to tuple

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -208,3 +208,4 @@ Phil McGachey <phil_mcgachey@harvard.edu>
 Sri Harsha Pamu <kmitharsha@gmail.com>
 Cris Ewing <cris@crisewing.com>
 Carlos de La Guardia <carlos@jazkarta.com>
+Albert Liang <albertliangcode@gmail.com>

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -547,7 +547,7 @@ PIPELINE_JS_COMPRESSOR = None
 
 STATICFILES_IGNORE_PATTERNS = (
     "*.py",
-    "*.pyc"
+    "*.pyc",
     # it would be nice if we could do, for example, "**/*.scss",
     # but these strings get passed down to the `fnmatch` module,
     # which doesn't support that. :(


### PR DESCRIPTION
Currently, Python implicitly concatenates two string entries located next to
each other because there is no comma separating them.  The code concatenates
"*.pyc" and "sass/*.scss", creating a single entry called "*.pycsass/*.scss".