### PR TITLE
Fix UI on Bulksettings Page

### DIFF
--- a/cms/static/sass/views/_bulksettings.scss
+++ b/cms/static/sass/views/_bulksettings.scss
@@ -40,36 +40,33 @@
             float: left;
         }
     }
-    
-    
-    .subsection-header {
-        background-color: #eee;
-
-        td > strong {
-            padding-left: 30px;
-        }
-    }
-    
-    .subsection-settings {
-        padding-right: 10px; 
-    }
-    
-    .unit-header {
-        td > strong {
-        padding-left: 50px;
-        }
-    }
-    .problem-header {
-        td > strong {
-            padding-left: 70px;
-        }
-    }
 
     .course-utility .settings-table {
         width: 100%;
 
         tr td {
             padding: 5px;
+        }
+
+        .subsection-header {
+            background-color: #eee;
+
+            .subsection-header-cell {
+                padding-left: 30px;
+            }
+        }
+        .subsection-settings {
+            padding-right: 10px;
+        }
+        .unit-header {
+            .unit-title {
+                padding-left: 50px;
+            }
+        }
+        .problem-header {
+            .problem-title {
+                padding-left: 70px;
+            }
         }
     }
 

--- a/cms/templates/bulksettings.html
+++ b/cms/templates/bulksettings.html
@@ -67,13 +67,13 @@
                             % for unit_settings in subsection_settings['children']:
                                 <tr class = "unit-header">
                                     <!-- TODO: dynamically allocate space ?-->
-                                    <td width = "92%" colspan="6"><strong><a href="${unit_settings['url']}">${unit_settings['name']}</a></strong></td>
+                                    <td width = "92%" colspan="6" class="unit-title"><strong><a href="${unit_settings['url']}">${unit_settings['name']}</a></strong></td>
                                     <td width = "8%">${unit_settings['ispublic']}</td> <!--hard coded right now-->
                                 </tr>
 
                                 % for problem_settings in unit_settings['children']:
                                     <tr class="problem-header">
-                                        <td width="52%"><strong><a href="${problem_settings['url']}">${problem_settings['name']}</a></strong></td>
+                                        <td width="52%" class="problem-title"><strong><a href="${problem_settings['url']}">${problem_settings['name']}</a></strong></td>
                                         % for setting_type in setting_type_list_map['problem_setting_types']:
                                             <td width="8%">${problem_settings[setting_type]}</td>
                                         % endfor

--- a/cms/templates/bulksettings.html
+++ b/cms/templates/bulksettings.html
@@ -81,7 +81,14 @@
                                         %>
                                         <td width="52%" class="problem-title"><strong><a href="${problem_settings['url']}">${problem_title}</a></strong></td>
                                         % for setting_type in setting_type_list_map['problem_setting_types']:
-                                            <td width="8%">${problem_settings[setting_type]}</td>
+                                            <%
+                                            problem_setting_type = problem_settings[setting_type]
+                                            if setting_type == 'weight':
+                                                problem_setting_type = problem_settings[setting_type] or '1'
+                                            elif setting_type == 'max_attempts':
+                                                problem_setting_type = problem_settings[setting_type] or 'unlimited'
+                                            %>
+                                            <td width="8%">${problem_setting_type}</td>
                                         % endfor
                                         <td width="8%"></td> <!-- Padding-->
                                     </tr>

--- a/cms/templates/bulksettings.html
+++ b/cms/templates/bulksettings.html
@@ -59,7 +59,10 @@
                                 <td class = "subsection-header-cell" colspan = "7">
                           <strong><a href="${subsection_settings['url']}">${subsection_settings['name']}</a></strong> -
                           % for setting_type in setting_type_list_map['subsection_setting_types']:
-                              <span title=${setting_type} class="subsection-settings"><strong>${subsection_setting_map[setting_type]}:</strong> ${subsection_settings[setting_type]}</span>
+                              <%
+                              subsection_setting = subsection_settings[setting_type] or 'N/A'
+                              %>
+                              <span title=${setting_type} class="subsection-settings"><strong>${subsection_setting_map[setting_type]}:</strong> ${subsection_setting}</span>
                           % endfor
                         </td>
                             </tr>

--- a/cms/templates/bulksettings.html
+++ b/cms/templates/bulksettings.html
@@ -76,7 +76,10 @@
 
                                 % for problem_settings in unit_settings['children']:
                                     <tr class="problem-header">
-                                        <td width="52%" class="problem-title"><strong><a href="${problem_settings['url']}">${problem_settings['name']}</a></strong></td>
+                                        <%
+                                        problem_title = problem_settings['name'] or 'Unnamed Problem'
+                                        %>
+                                        <td width="52%" class="problem-title"><strong><a href="${problem_settings['url']}">${problem_title}</a></strong></td>
                                         % for setting_type in setting_type_list_map['problem_setting_types']:
                                             <td width="8%">${problem_settings[setting_type]}</td>
                                         % endfor


### PR DESCRIPTION
Repaired minor errors in how text was being displayed on page.

After this fix:
- Text wraps around to correct indent
- Max Attempts setting defaults to "-"
- Weight setting defaults to "1"
- Subsection due dates and types default to "N/A"
- Problem names default to "Unnamed Problem"