### PR TITLE
Exclude `test_root` from PEP8 check

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,4 +29,4 @@ no-path-adjustment=1
 #   It's a little unusual, but we have good reasons for doing so, so we disable
 #   this rule.
 ignore=E501,E265,W602
-exclude=migrations
+exclude=migrations,test_root/


### PR DESCRIPTION
I'm not yet sure what caused it, but Jenkins has started scanning the
`edx-platform/test_root` directory for PEP8 violations. Violations in
this code cause the quality check to fail, subsequently failing the
entire suite.

TODO: Figure out why `test_root` is being checked for quality violations.