### PR TITLE
Remove name on dashboard sidebar

### DIFF
--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -155,7 +155,7 @@
 
   <section class="profile-sidebar" id="profile-sidebar" role="region" aria-label="User info">
     <header class="profile">
-      <h2 class="username-header"><span class="sr">${_("Username")}: </span><span class="username-label">${ user.username }</span></h2>
+      <h2 class="username-header"><span class="sr">${_("Username")}: </span></h2>
     </header>
     <section class="user-info">
       <ul>


### PR DESCRIPTION
@dcadams & @stvstnfrd - fix for dashboard name bug.

I'm just making the change that would have come in on next merge...