### PR TITLE
Modify TOS and PP Links

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -247,8 +247,8 @@ from edxmako.shortcuts import marketing_link
         <section class="unauth-tos" id="unauth-tos">
           <p>
             * ${_("By exploring the course, you are agreeing to our {tos_link_start}Terms of Service{link_end} and {privacy_link_start}Privacy Policy{link_end}. Please read them carefully.").format(
-              tos_link_start='<a href="/tos">',
-              privacy_link_start='<a href="/tos#privacy">',
+              tos_link_start='<a href="https://lagunita.stanford.edu/tos">',
+              privacy_link_start='<a href="https://lagunita.stanford.edu/tos#privacy">',
               link_end='</a>'
             )}
           </p>

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -257,8 +257,8 @@ ${fragment.foot_html()}
   % if course and user.is_authenticated() and not UserProfile.has_registered(user):
     <div class="unauth-tos">
       ${_("By exploring the course, you are agreeing to our {tos_link_start}Terms of Service{link_end} and {privacy_link_start}Privacy Policy{link_end}. Please read them carefully.").format(
-        tos_link_start='<a href="/tos">',
-        privacy_link_start='<a href="/tos#privacy">',
+        tos_link_start='<a href="https://lagunita.stanford.edu/tos">',
+        privacy_link_start='<a href="https://lagunita.stanford.edu/tos#privacy">',
         link_end='</a>'
       )}
     </div>


### PR DESCRIPTION
If Direct Access is enabled for a course on
Lagunita or SUclass, special links are added
to the bottom of the About and Courseware pages.
These links point to the ToS and Privacy Policy
of each site. But since SUclass does not have a
ToS page, these links are broken.

This commit makes these links point to the Lagunita
TOS and PP. This is based on the proposed solution in
https://docs.google.com/document/d/1c6Q2YIUKFrChWzbCIwHNHx-XDeLzY1m9pFvBXiJi7XU/edit
Until Marc / the OGC write an appropriate direct-access-only
version of the TOS and Privacy Policy