### PR TITLE
Attempt to find a solution to the tracking log issue.

### DIFF
--- a/common/djangoapps/track/tests/test_middleware.py
+++ b/common/djangoapps/track/tests/test_middleware.py
@@ -145,3 +145,19 @@ class TrackMiddlewareTestCase(TestCase):
             'ip': ip_address,
             'agent': user_agent,
         })
+
+    @patch('track.middleware.TRUNCATION_LENGTH', 6)
+    def test_student_answer_request(self):
+        request = self.request_factory.post('/dummy')
+        request.POST = {'student_answer': ['firstanswer', 'secondanswer']}
+        self.track_middleware.process_request(request)
+        event = '{"POST": {"student_answer": ["fir", "sec"]}, "GET": {}}'
+        self.mock_server_track.assert_called_with(request, request.META['PATH_INFO'], event)
+
+    @patch('track.middleware.TRUNCATION_LENGTH', 20)
+    def test_submission_request(self):
+        request = self.request_factory.post('/dummy')
+        request.POST = {'{"submission":["first open response", "second open response"]}': []}
+        self.track_middleware.process_request(request)
+        event = '{"POST": {"submission": ["first open", "second ope"]}, "GET": {}}'
+        self.mock_server_track.assert_called_with(request, request.META['PATH_INFO'], event)


### PR DESCRIPTION
The issue is that some, mostly openended, responses get truncated
by the current 512 char limit.

Additionally, the tracking log entry is written as invalid json
when such a primitive truncate is applied.

The limit is now 4096 chars and this is distributed across all
student responses in the event.