### PR TITLE
Fix of discussion test broken by direct access

### DIFF
--- a/lms/djangoapps/django_comment_client/forum/tests.py
+++ b/lms/djangoapps/django_comment_client/forum/tests.py
@@ -36,6 +36,7 @@ from mock import patch, Mock, ANY, call
 from openedx.core.djangoapps.course_groups.models import CourseUserGroup
 
 from teams.tests.factories import CourseTeamFactory
+from student.models import UserProfile
 
 log = logging.getLogger(__name__)
 
@@ -718,6 +719,9 @@ class InlineDiscussionContextTestCase(ModuleStoreTestCase):
             discussion_topic_id=self.discussion_topic_id
         )
         self.team.add_user(self.user)  # pylint: disable=no-member
+
+        # Create the user a UserProfile so it doesn't act as a direct access user
+        UserProfile(user=self.user).save()
 
     def test_context_can_be_standalone(self, mock_request):
         mock_request.side_effect = make_mock_request_impl(


### PR DESCRIPTION
The following commit:
https://github.com/Stanford-Online/edx-platform/commit/d0d6285c93f6dfde9c0e9f27e75bea08ec3e2454
restricted forum usage to non-direct access users. However this caused the test to break
as the test user was created without a UserProfile and, in effect, was a direct access
user.