### PR TITLE
Remove CSV columns and rename report file

### DIFF
--- a/lms/djangoapps/instructor/tests/test_tools.py
+++ b/lms/djangoapps/instructor/tests/test_tools.py
@@ -365,26 +365,26 @@ class TestGenerateD3CourseForums(unittest.TestCase):
         """
         Test Generating d3 usable csvs
         """
-        data_string = """ Date,Type,Number,Up Votes,Down Votes,Net Points
-2014-10-8,CommentThread,2,3,0,3
-2014-10-10,CommentThread,1,4,0,4
-2014-10-10,Response,1,3,0,3
-2014-10-11,CommentThread,1,0,0,0
-2014-10-11,Response,5,2,0,2
-2014-10-11,Comment,2,0,0,0
-2014-10-12,CommentThread,1,0,0,0
-2014-10-12,Response,1,0,0,0
-2014-10-12,Comment,1,0,0,0
-2014-10-13,CommentThread,16,5,0,5
-2014-10-13,Response,23,5,0,5
-2014-10-13,Comment,9,0,0,0
-2014-10-14,CommentThread,20,6,0,6
-2014-10-14,Response,51,4,0,4
-2014-10-14,Comment,17,0,0,0
-2014-10-15,CommentThread,18,1,0,1
-2014-10-15,Response,43,13,0,13
-2014-10-15,Comment,18,0,0,0
-2014-10-16,CommentThread,10,3,0,3 """
+        data_string = """ Date,Activity Type,Number New,Votes
+2014-10-8,CommentThread,2,3
+2014-10-10,CommentThread,1,4
+2014-10-10,Response,1,3
+2014-10-11,CommentThread,1,0
+2014-10-11,Response,5,2
+2014-10-11,Comment,2,0
+2014-10-12,CommentThread,1,0
+2014-10-12,Response,1,0
+2014-10-12,Comment,1,0
+2014-10-13,CommentThread,16,5
+2014-10-13,Response,23,5
+2014-10-13,Comment,9,0
+2014-10-14,CommentThread,20,6
+2014-10-14,Response,51,4
+2014-10-14,Comment,17,0
+2014-10-15,CommentThread,18,1
+2014-10-15,Response,43,13
+2014-10-15,Comment,18,0
+2014-10-16,CommentThread,10,3"""
         memfile = StringIO.StringIO(data_string)
         output = tools.generate_course_forums_d3(memfile)
         to_match = """Date,New Threads,Responses,Comments
@@ -398,11 +398,23 @@ class TestGenerateD3CourseForums(unittest.TestCase):
 2014-10-16,10,0,0"""
         self.assertEquals(output, to_match)
 
+    def test_edge_case(self):
+        """
+        Test Generating d3 usable csvs
+        """
+        data_string = """ Date,Activity Type,Number New,Votes
+2014-10-8,CommentThread,2,3"""
+        memfile = StringIO.StringIO(data_string)
+        output = tools.generate_course_forums_d3(memfile)
+        to_match = """Date,New Threads,Responses,Comments
+2014-10-8,2,0,0"""
+        self.assertEquals(output, to_match)
+
     def test_no_data(self):
         """
         Test Generating d3 usable csvs
         """
-        data_string = "Date,Type,Number,Up Votes,Down Votes,Net Points"
+        data_string = "Date,Activity Type,Number New,Votes"
         memfile = StringIO.StringIO(data_string)
         output = tools.generate_course_forums_d3(memfile)
         self.assertIsNone(output)

--- a/lms/djangoapps/instructor/utils.py
+++ b/lms/djangoapps/instructor/utils.py
@@ -75,13 +75,11 @@ def collect_course_forums_data(course_id):
             "{0}-{1}-{2}".format(result['_id']['year'], result['_id']['month'], result['_id']['day']),
             result['_id']['type'],
             result['posts'],
-            result['up_votes'],
-            result['down_votes'],
-            result['net_points'],
+            result['votes'],
         ]
         for result in results
     ]
-    header = ['Date', 'Type', 'Number', 'Up Votes', 'Down Votes', 'Net Points']
+    header = ['Date', 'Activity Type', 'Number New', 'Votes']
     return header, parsed_results
 
 
@@ -151,9 +149,7 @@ def generate_course_forums_query(course_id, query_type, parent_id_check=None):
                 'type': '$type',
             },
             'posts': {"$sum": 1},
-            'net_points': {'$sum': '$votes.point'},
-            'up_votes': {'$sum': '$votes.up_count'},
-            'down_votes': {'$sum': '$votes.down_count'},
+            'votes': {'$sum': '$votes.up_count'},
         }},
         # order of the sort is important so we use SON
         {'$sort': SON([('_id.year', 1), ('_id.month', 1), ('_id.day', 1)])},

--- a/lms/djangoapps/instructor/views/tools.py
+++ b/lms/djangoapps/instructor/views/tools.py
@@ -280,7 +280,9 @@ def generate_course_forums_d3(url_handle):
     previous_date = -1
     previous = None
     rows = [['Date', 'New Threads', 'Responses', 'Comments']]
-    for date, comment_type, number, up_vote, down, net in reader:  # pylint: disable=unused-variable
+    for row in reader:
+        # this is for backward compatibility because there is a variable number of columns. we only want the first 3
+        date, comment_type, number = row[0:3]
         if date != previous_date:
             if previous:
                 rows.append([previous_date] + previous)
@@ -293,7 +295,7 @@ def generate_course_forums_d3(url_handle):
         elif comment_type == 'Comment':
             previous[2] = number
     # return nothing if there's no data
-    if len(rows) == 1:
+    if not previous:
         return None
     else:
         # get the last row's stuff

--- a/lms/djangoapps/instructor_task/api.py
+++ b/lms/djangoapps/instructor_task/api.py
@@ -377,7 +377,7 @@ def submit_course_forums_usage_task(request, course_key):
     """
     AlreadyRunningError is raised if an course forums usage report is already being generated.
     """
-    task_type = 'course_forums'
+    task_type = 'course_forums_usage'
     task_class = get_course_forums_usage
     task_input = {}
     task_key = ''

--- a/lms/djangoapps/instructor_task/tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tasks_helper.py
@@ -855,7 +855,7 @@ def push_course_forums_data_to_s3(_xmodule_instance_args, _entry_id, course_id, 
     """
     Collect course forums usage data and upload them to S3 as a CSV
     """
-    return _push_csv_responses_to_s3(collect_course_forums_data, u'course_forums', course_id, action_name)
+    return _push_csv_responses_to_s3(collect_course_forums_data, u'course_forums_usage', course_id, action_name)
 
 
 def push_student_forums_data_to_s3(_xmodule_instance_args, _entry_id, course_id, _task_input, action_name):

--- a/lms/djangoapps/instructor_task/tests/test_api.py
+++ b/lms/djangoapps/instructor_task/tests/test_api.py
@@ -244,7 +244,14 @@ class InstructorTaskCourseSubmitTest(TestReportMixin, InstructorTaskCourseTestCa
             mock_submit_task.return_value = MagicMock()
             submit_course_forums_usage_task(request, self.course.id)
 
-            mock_submit_task.assert_called_once_with(request, 'course_forums', get_course_forums_usage, self.course.id, {}, '')
+            mock_submit_task.assert_called_once_with(
+                request,
+                'course_forums_usage',
+                get_course_forums_usage,
+                self.course.id,
+                {},
+                '',
+            )
 
     def test_submit_student_forums_usage_task(self):
         request = self.create_task_request(self.instructor)


### PR DESCRIPTION
from course forums usage report

Per Jim Cai:
> Removing deprecated/Renaming columns and files
> old filename: %course%_course_forums_%date% new filename:
> %course%_course_forums_usage_%date%
>
> old column names: Date,Type,Number,Up Votes,Down Votes,Net Points
> new names: Date,Activity Type,Number New,Votes
>
> Also fixed a bug when there is only 1 row

Conflicts:
	lms/djangoapps/instructor/views/tools.py