### PR TITLE
Remove unused forked CSS from legacy dashboard

### DIFF
--- a/lms/templates/courseware/legacy_instructor_dashboard.html
+++ b/lms/templates/courseware/legacy_instructor_dashboard.html
@@ -116,55 +116,6 @@ textarea {
     top: 30px;
 }
 
-.metrics-container {
-    position: relative;
-    width: 100%;
-    float: left;
-    clear: both;
-    margin-top: 25px;
-}
-.metrics-left {
-    position: relative;
-    width: 30%;
-    height: 640px;
-    float: left;
-    margin-right: 2.5%;
-}
-.metrics-right {
-    position: relative;
-    width: 65%;
-    height: 295px;
-    float: left;
-    margin-left: 2.5%;
-    margin-bottom: 25px;
-}
-
-.metrics-tooltip {
-    width: 250px;
-    background-color: lightgray;
-    padding: 3px;
-}
-
-.stacked-bar-graph-legend {
-    fill: white;
-}
-
-p.loading {
-  padding-top: 100px;
-  text-align: center;
-}
-
-p.nothing {
-  padding-top: 25px;
-}
-
-h3.attention {
-  padding: 10px;
-  border: 1px solid #999;
-  border-radius: 5px;
-  margin-top: 25px;
-}
-
 </style>
 
 <script language="JavaScript" type="text/javascript">


### PR DESCRIPTION
This styles elements that don't exist on the page.

This page has already been deprecated upstream and will be removed soon.