### PR TITLE
Remove anonymous users from reports

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -823,10 +823,17 @@ class CourseEnrollmentManager(models.Manager):
 
     def users_enrolled_in(self, course_id):
         """Return a queryset of User for every user enrolled in the course."""
-        return User.objects.filter(
+        course_users = User.objects.filter(
             courseenrollment__course_id=course_id,
-            courseenrollment__is_active=True
+            courseenrollment__is_active=True,
         )
+        anonymous_user_ids = [
+            user.id
+            for user in course_users
+            if not UserProfile.has_registered(user)
+        ]
+        enrolled_course_users = course_users.exclude(id__in=anonymous_user_ids)
+        return enrolled_course_users
 
     def enrollment_counts(self, course_id):
         """

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -1606,7 +1606,7 @@ class TestCertificateGeneration(InstructorTaskModuleTestCase):
 
         current_task = Mock()
         current_task.update_state = Mock()
-        with self.assertNumQueries(125):
+        with self.assertNumQueries(136):
             with patch('instructor_task.tasks_helper._get_current_task') as mock_current_task:
                 mock_current_task.return_value = current_task
                 with patch('capa.xqueue_interface.XQueueInterface.send_to_queue') as mock_queue:


### PR DESCRIPTION
For courses that have direct access enabled, the presence
of unauthenticated users in the reporting data can cause
confusion and delay. Depending on the size of the course, and the
number of problems in the course, the report can take
more than 48 hours to generate. Removing anonymous users
from reports will alleviate some of this strain. As proposed
by issue LE-660: https://lagunita.atlassian.net/browse/LE-660
this commit removes anonymous users from reports.