### PR TITLE
Enable discussion home panel

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -110,7 +110,7 @@ FEATURES = {
 
     # discussion home panel, which includes a subscription on/off setting for discussion digest emails.
     # this should remain off in production until digest notifications are online.
-    'ENABLE_DISCUSSION_HOME_PANEL': False,
+    'ENABLE_DISCUSSION_HOME_PANEL': True,
 
     # Set this to True if you want the discussion digest emails enabled automatically for new users.
     # This will be set on all new account registrations.


### PR DESCRIPTION
This dates back 2-3 years ago, to a time when the digest emails weren't
fully implemented. This flag was used to toggle off the landing page, in
an apparently heavy-handed attempt to hide the enroll/unenroll checkbox.

Without this feature enabled, the discussions landing page is
disturbingly empty; that's never what we want.

Long term, this flag should be removed entirely, via an upstream PR (to
be immediately cherry-picked to our fork.