### PR TITLE
Display correct timezone on timestamp for question submission

### DIFF
--- a/lms/djangoapps/courseware/tests/test_views.py
+++ b/lms/djangoapps/courseware/tests/test_views.py
@@ -7,6 +7,7 @@ from urllib import urlencode
 import ddt
 import json
 import unittest
+import pytz
 from datetime import datetime
 from HTMLParser import HTMLParser
 from nose.plugins.attrib import attr
@@ -17,6 +18,7 @@ from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponseBadRequest
 from django.test import TestCase
 from django.test.client import RequestFactory
+from django.test.client import Client
 from django.test.utils import override_settings
 from mock import MagicMock, patch, create_autospec, Mock
 from opaque_keys.edx.locations import Location, SlashSeparatedCourseKey
@@ -560,7 +562,6 @@ class ViewsTestCase(ModuleStoreTestCase):
         })
         response = self.client.get(url)
         response_content = HTMLParser().unescape(response.content)
-
         # We have update the state 4 times: twice to change content, and twice
         # to set the scores. We'll check that the identifying content from each is
         # displayed (but not the order), and also the indexes assigned in the output
@@ -572,6 +573,34 @@ class ViewsTestCase(ModuleStoreTestCase):
         self.assertIn(json.dumps({'field_a': 'x', 'field_b': 'y'}, sort_keys=True, indent=2), response_content)
         self.assertIn("Score: 3.0 / 3.0", response_content)
         self.assertIn('#4', response_content)
+
+    @ddt.data('America/New_York',  # UTC - 5
+              'Asia/Pyongyang',      # UTC + 9
+              'Europe/London',       # UTC
+              'Canada/Yukon',        # UTC - 8
+              'Europe/Moscow',)      # UTC + 3
+    def test_submission_history_timezone(self, timezone):
+        with (override_settings(TIME_ZONE=timezone)):
+            course = CourseFactory.create()
+            course_key = course.id
+            client = Client()
+            admin = AdminFactory.create()
+            client.login(username=admin.username, password='test')
+            state_client = DjangoXBlockUserStateClient(admin)
+            usage_key = course_key.make_usage_key('problem', 'test-history')
+            state_client.set(
+                username=admin.username,
+                block_key=usage_key,
+                state={'field_a': 'x', 'field_b': 'y'}
+            )
+            url = reverse('submission_history', kwargs={
+                'course_id': unicode(course_key),
+                'student_username': admin.username,
+                'location': unicode(usage_key),
+            })
+            response = client.get(url)
+            response_content = HTMLParser().unescape(response.content)
+            self.assertIn(settings.TIME_ZONE, response_content)
 
     def _load_mktg_about(self, language=None, org=None):
         """Retrieve the marketing about button (iframed into the marketing site)

--- a/lms/templates/courseware/submission_history.html
+++ b/lms/templates/courseware/submission_history.html
@@ -1,10 +1,10 @@
-<% import json  %>
+<% import json, pytz %>
 <h3>${username | h} > ${course_id | h} > ${location | h}</h3>
 
 % for i, (entry, score) in enumerate(zip(history_entries, scores)):
 <hr/>
 <div>
-<b>#${len(history_entries) - i}</b>: ${entry.updated} (${TIME_ZONE} time)</br>
+<b>#${len(history_entries) - i}</b>: ${entry.updated.astimezone(pytz.timezone(settings.TIME_ZONE))} (${settings.TIME_ZONE} time)</br>
 Score: ${score.grade} / ${score.max_grade}
 <pre>
 ${json.dumps(entry.state, indent=2, sort_keys=True) | h}


### PR DESCRIPTION
The view for submission history used to grab the timezone from the database (UTC) and appeded the TIME_ZONE variable after (could be any time zone). Adjusted displayed timedate to the TIME_ZONE variable.