### PR TITLE
Add optional field to sysadmin regen_certs

### DIFF
--- a/lms/static/js/sysadmin/mgmt_commands.js
+++ b/lms/static/js/sysadmin/mgmt_commands.js
@@ -67,6 +67,11 @@
                     'required': false
                 },
                 {
+                    'argument': 'designation',
+                    'display_name': gettext('designation'),
+                    'required': false
+                },
+                {
                     'argument': 'template_file',
                     'display_name': gettext('template'),
                     'required': false


### PR DESCRIPTION
This commit adds an optional field 'designation'
to the regen_certs (Generate a single certificate)
management command on the sysadmin dashboard.