### PR TITLE
Disable Django pipeline compression in devstack

### DIFF
--- a/cms/envs/devstack.py
+++ b/cms/envs/devstack.py
@@ -4,6 +4,8 @@ Specific overrides to the base prod settings to make development easier.
 
 from .aws import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
+FEATURES['USE_DJANGO_PIPELINE'] = False
+
 # Don't use S3 in devstack, fall back to filesystem
 del DEFAULT_FILE_STORAGE
 MEDIA_ROOT = "/edx/var/edxapp/uploads"

--- a/lms/envs/devstack.py
+++ b/lms/envs/devstack.py
@@ -4,6 +4,8 @@ Specific overrides to the base prod settings to make development easier.
 
 from .aws import *  # pylint: disable=wildcard-import, unused-wildcard-import
 
+FEATURES['USE_DJANGO_PIPELINE'] = False
+
 # Don't use S3 in devstack, fall back to filesystem
 del DEFAULT_FILE_STORAGE
 MEDIA_ROOT = "/edx/var/edxapp/uploads"


### PR DESCRIPTION
This should not only speeds things up, but more importantly, makes it
easier to debug during development.