### PR TITLE
Add submit-and-compare and freetextresponse xblocks to the student responses report.

### DIFF
--- a/lms/djangoapps/instructor_analytics/tests/test_basic.py
+++ b/lms/djangoapps/instructor_analytics/tests/test_basic.py
@@ -531,3 +531,58 @@ class TestStudentResponsesAnalyticsBasic(ModuleStoreTestCase):
         datarows = list(student_responses(self.course))
         #Invalid module state response will be skipped, so datarows should be empty
         self.assertEqual(len(datarows), 0)
+
+    def test_problem_with_student_answer_and_answers(self):
+        self.course = get_course(CourseKey.from_string('edX/graded/2012_Fall'))
+        problem_location = Location('edX', 'graded', '2012_Fall', 'problem', 'H1P2')
+
+        self.create_student()
+        StudentModuleFactory.create(
+            course_id=self.course.id,
+            module_state_key=problem_location,
+            student=self.student,
+            grade=0,
+            state=u'{"student_answers":{"problem_id":"student response1"}}',
+        )
+
+        submit_and_compare_location = Location('edX', 'graded', '2012_Fall', 'problem', 'H1P3')
+        StudentModuleFactory.create(
+            course_id=self.course.id,
+            module_state_key=submit_and_compare_location,
+            student=self.student,
+            grade=0,
+            state=u'{"student_answer": "student response2"}',
+        )
+
+        submit_and_compare_location = Location("edX", "graded", "2012_Fall", "problem", 'H1P0')
+        StudentModuleFactory.create(
+            course_id=self.course.id,
+            module_state_key=submit_and_compare_location,
+            student=self.student,
+            grade=0,
+            state=u'{"answer": {"problem_id": "123"}}',
+        )
+
+#         datarows = list(student_response_rows(self.course))
+#         self.assertEqual(datarows[1][-1], u'problem_id=student response1')
+#         self.assertEqual(datarows[2][-1], u'i4x://edX/graded/problem/H1P3=student response2')
+
+        datarows = list(student_responses(self.course))
+        self.assertEqual(datarows[0][-1], u'problem_id=student response1')
+        self.assertEqual(datarows[1][-1], u'i4x://edX/graded/problem/H1P3=student response2')
+
+    def test_problem_with_no_answer(self):
+        self.course = get_course(CourseKey.from_string('edX/graded/2012_Fall'))
+        problem_location = Location('edX', 'graded', '2012_Fall', 'problem', 'H1P2')
+
+        self.create_student()
+        StudentModuleFactory.create(
+            course_id=self.course.id,
+            module_state_key=problem_location,
+            student=self.student,
+            grade=0,
+            state=u'{"answer": {"problem_id": "123"}}',
+        )
+
+        datarows = list(student_responses(self.course))
+        self.assertEqual(datarows[0][-1], None)

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2766,3 +2766,9 @@ PROCTORING_BACKEND_PROVIDER = {
     'options': {},
 }
 PROCTORING_SETTINGS = {}
+
+STUDENT_RESPONSES_REPORT_SUPPORTED_TYPES = set([
+    'problem',
+    'submit-and-compare',
+    'freetextresponse',
+])


### PR DESCRIPTION
The PR adds the student responses for submit and compare 
and free text response xblocks to the student responses report.

The report is now generated for valid types which are has a setting.

Tests have been added to test a positive outcome.