### PR TITLE
Revert "Temporarily add analytics 5s timeout"

### DIFF
--- a/lms/djangoapps/class_dashboard/dashboard_data.py
+++ b/lms/djangoapps/class_dashboard/dashboard_data.py
@@ -95,7 +95,7 @@ def get_problem_grade_distribution(course_id, enrollment):
         course = modulestore().get_course(course_id, depth=4)
 
         # Connect to analytics data client
-        client = Client(base_url=settings.ANALYTICS_DATA_URL, auth_token=settings.ANALYTICS_DATA_TOKEN, timeout=5)
+        client = Client(base_url=settings.ANALYTICS_DATA_URL, auth_token=settings.ANALYTICS_DATA_TOKEN)
 
         for section in course.get_children():
             for subsection in section.get_children():
@@ -158,7 +158,7 @@ def get_sequential_open_distrib(course_id, enrollment):
         course = modulestore().get_course(course_id, depth=2)
 
         # Connect to analytics data client
-        client = Client(base_url=settings.ANALYTICS_DATA_URL, auth_token=settings.ANALYTICS_DATA_TOKEN, timeout=5)
+        client = Client(base_url=settings.ANALYTICS_DATA_URL, auth_token=settings.ANALYTICS_DATA_TOKEN)
 
         for section in course.get_children():
             for subsection in section.get_children():
@@ -224,7 +224,7 @@ def get_problem_set_grade_distrib(course_id, problem_set, enrollment):
                 curr_grade_distrib['max_grade'] = row['max_grade']
     else:
         # Connect to analytics data client
-        client = Client(base_url=settings.ANALYTICS_DATA_URL, auth_token=settings.ANALYTICS_DATA_TOKEN, timeout=5)
+        client = Client(base_url=settings.ANALYTICS_DATA_URL, auth_token=settings.ANALYTICS_DATA_TOKEN)
 
         for problem in problem_set:
             module = client.modules(course_id, problem)

--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -1432,7 +1432,7 @@ def get_analytics_answer_dist(request):
     if not having_access or not url:
         return HttpResponseServerError(error_message)
 
-    client = Client(base_url=url, auth_token=auth_token, timeout=5)
+    client = Client(base_url=url, auth_token=auth_token)
     module = client.modules(course.id, module_id)
 
     try:


### PR DESCRIPTION
This reverts the hotfix made last Friday to the analytics client timeout in order to keep inline analytics and the metrics tab going in production (commit dcc9ec08599ba2d94e4c4706454061128443529d).  The permanent fix has been made and the client version updated, so it's time to take this back out. @dcadams @stvstnfrd 