### PR TITLE
Alter CME gender choices to m and f.

### DIFF
--- a/common/djangoapps/cme_registration/models.py
+++ b/common/djangoapps/cme_registration/models.py
@@ -460,5 +460,5 @@ class CmeUserProfile(UserProfile):
                        ('Other', 'Other'))
 
     country_cme = models.CharField(blank=True, null=True, max_length=50, choices=COUNTRY_CHOICES)
-    GENDER_CHOICES = (('M', 'Male'),
-                      ('F', 'Female'))
+    GENDER_CHOICES = (('m', 'Male'),
+                      ('f', 'Female'))


### PR DESCRIPTION
Upstream code validates against gender values of m and f. Previously,
CME gender values were M and F which caused an exception when
using the account/settings page.

Altering the existing gender values in the db will be a seperate process once this lands.

Also, @dylanrhodes will have to change the report script to report upper case values of gender.