### PR TITLE
Remove DEFAULT_STORE_FOR_NEW_COURSE setting

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -86,7 +86,6 @@ def requires_pillow_jpeg(func):
     return decorated_func
 
 
-@override_settings(DEFAULT_STORE_FOR_NEW_COURSE=None)
 @override_settings(CONTENTSTORE=TEST_DATA_CONTENTSTORE)
 class ContentStoreTestCase(CourseTestCase):
     """
@@ -1273,8 +1272,7 @@ class ContentStoreTest(ContentStoreTestCase, XssTestMixin):
         except InvalidKeyError:
             # b/c the intent of the test with bad chars isn't to test auth but to test the handler, ignore
             pass
-        with mock.patch.dict('django.conf.settings.FEATURES', {"DEFAULT_STORE_FOR_NEW_COURSE": None}):
-            resp = self.client.ajax_post('/course/', self.course_data)
+        resp = self.client.ajax_post('/course/', self.course_data)
         self.assertEqual(resp.status_code, 200)
         data = parse_json(resp)
         self.assertRegexpMatches(data['ErrMsg'], error_message)
@@ -1285,8 +1283,7 @@ class ContentStoreTest(ContentStoreTestCase, XssTestMixin):
 
     def test_create_course_duplicate_number(self):
         """Test new course creation - error path"""
-        with mock.patch.dict('django.conf.settings.FEATURES', {"DEFAULT_STORE_FOR_NEW_COURSE": None}):
-            self.client.ajax_post('/course/', self.course_data)
+        self.client.ajax_post('/course/', self.course_data)
         self.course_data['display_name'] = 'Robot Super Course Two'
         self.course_data['run'] = '2013_Summer'
 
@@ -1295,8 +1292,7 @@ class ContentStoreTest(ContentStoreTestCase, XssTestMixin):
     def test_create_course_case_change(self):
         """Test new course creation - error path due to case insensitive name equality"""
         self.course_data['number'] = 'capital'
-        with mock.patch.dict('django.conf.settings.FEATURES', {"DEFAULT_STORE_FOR_NEW_COURSE": None}):
-            self.client.ajax_post('/course/', self.course_data)
+        self.client.ajax_post('/course/', self.course_data)
         cache_current = self.course_data['org']
         self.course_data['org'] = self.course_data['org'].lower()
         self.assert_course_creation_failed('There is already a course defined with the same organization and course number. Please change either organization or course number to be unique.')
@@ -2152,13 +2148,12 @@ def _create_course(test, course_key, course_data):
     """
     Creates a course via an AJAX request and verifies the URL returned in the response.
     """
-    with mock.patch.dict('django.conf.settings.FEATURES', {"DEFAULT_STORE_FOR_NEW_COURSE": None}):
-        course_url = get_url('course_handler', course_key, 'course_key_string')
-        response = test.client.ajax_post(course_url, course_data)
-        test.assertEqual(response.status_code, 200)
-        data = parse_json(response)
-        test.assertNotIn('ErrMsg', data)
-        test.assertEqual(data['url'], course_url)
+    course_url = get_url('course_handler', course_key, 'course_key_string')
+    response = test.client.ajax_post(course_url, course_data)
+    test.assertEqual(response.status_code, 200)
+    data = parse_json(response)
+    test.assertNotIn('ErrMsg', data)
+    test.assertEqual(data['url'], course_url)
 
 
 def _get_course_id(store, course_data):

--- a/cms/djangoapps/contentstore/tests/test_permissions.py
+++ b/cms/djangoapps/contentstore/tests/test_permissions.py
@@ -31,16 +31,15 @@ class TestCourseAccess(ModuleStoreTestCase):
         # create a course via the view handler which has a different strategy for permissions than the factory
         self.course_key = self.store.make_course_key('myu', 'mydept.mycourse', 'myrun')
         course_url = reverse_url('course_handler')
-        with mock.patch.dict('django.conf.settings.FEATURES', {"DEFAULT_STORE_FOR_NEW_COURSE": None}):
-            self.client.ajax_post(
-                course_url,
-                {
-                    'org': self.course_key.org,
-                    'number': self.course_key.course,
-                    'display_name': 'My favorite course',
-                    'run': self.course_key.run,
-                }
-            )
+        self.client.ajax_post(
+            course_url,
+            {
+                'org': self.course_key.org,
+                'number': self.course_key.course,
+                'display_name': 'My favorite course',
+                'run': self.course_key.run,
+            }
+        )
 
         self.users = self._create_users()
 

--- a/cms/djangoapps/contentstore/tests/test_users_default_role.py
+++ b/cms/djangoapps/contentstore/tests/test_users_default_role.py
@@ -33,16 +33,15 @@ class TestUsersDefaultRole(ModuleStoreTestCase):
         """
         Create course at provided location
         """
-        with mock.patch.dict('django.conf.settings.FEATURES', {"DEFAULT_STORE_FOR_NEW_COURSE": None}):
-            resp = self.client.ajax_post(
-                reverse_url('course_handler'),
-                {
-                    'org': course_key.org,
-                    'number': course_key.course,
-                    'display_name': 'test course',
-                    'run': course_key.run,
-                }
-            )
+        resp = self.client.ajax_post(
+            reverse_url('course_handler'),
+            {
+                'org': course_key.org,
+                'number': course_key.course,
+                'display_name': 'test course',
+                'run': course_key.run,
+            }
+        )
         return resp
 
     def tearDown(self):

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -123,9 +123,6 @@ FEATURES = {
     # Turn off Advanced Security by default
     'ADVANCED_SECURITY': False,
 
-    # Modulestore to use for new courses
-    'DEFAULT_STORE_FOR_NEW_COURSE': None,
-
     # Display option to send email confirmation of course enrollment
     'ENABLE_ENROLLMENT_EMAIL': False,
 


### PR DESCRIPTION
This is something that JimC had added when attempting to work with
split-mongo. We don't need it now.