### PR TITLE
Add update_cert_status management command

### DIFF
--- a/lms/djangoapps/certificates/management/commands/update_cert_status.py
+++ b/lms/djangoapps/certificates/management/commands/update_cert_status.py
@@ -1,0 +1,112 @@
+"""
+Management command to update the status of a single user certificate
+for a given user, in a given course. If no --status kwarg is provided,
+the status will be updated to CertificiateStatuses.unavailable.
+"""
+from __future__ import print_function
+
+import logging
+from optparse import make_option
+
+from django.contrib.auth.models import User
+from django.core.management.base import BaseCommand
+from django.core.management.base import CommandError
+
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
+from opaque_keys.edx.locations import SlashSeparatedCourseKey
+
+from certificates.models import CertificateStatuses
+from certificates.models import GeneratedCertificate
+
+LOGGER = logging.getLogger(__name__)
+
+VALID_STATUSES = [
+    CertificateStatuses.unavailable,
+    CertificateStatuses.downloadable,
+    CertificateStatuses.notpassing,
+]
+
+
+class Command(BaseCommand):
+    """
+    Update the status of a single user certificate for a given user in a given course
+    """
+    help = __doc__
+    option_list = BaseCommand.option_list + (
+        make_option(
+            '-c', '--course-id',
+            default=False,
+            help='The course id (e.g. mit/6-002x/circuits-and-electronics or course-v1:edX+DemoX+Demo_Course)'
+                 ' of the course in which the certificate of the student should be updated',
+        ),
+        make_option(
+            '-u', '--username-or-email',
+            default=False,
+            help='The username or email address for whom grading and certificate status should be updated',
+        ),
+        make_option(
+            '-s', '--status',
+            default=CertificateStatuses.unavailable,
+            help='The status to set to the corresponding certificate',
+        ),
+    )
+
+    def handle(self, *args, **options):
+        if options['course_id']:
+            # try to parse out the course from the serialized form
+            try:
+                course_id = CourseKey.from_string(options['course_id'])
+            except InvalidKeyError:
+                course_id = SlashSeparatedCourseKey.from_deprecated_string(options['course_id'])
+        else:
+            raise CommandError(u'course-id is required')
+
+        user = options['username_or_email']
+        if not user:
+            raise CommandError(u'username-or-email is required')
+
+        status = options['status']
+
+        if status not in VALID_STATUSES:
+            raise CommandError(
+                u"INVALID STATUS. "
+                "Supported Statuses: {statuses}".format(
+                    statuses=', '.join(
+                        "`{status}`".format(
+                            status=status
+                        )
+                        for status in VALID_STATUSES
+                    )
+                )
+            )
+
+        if '@' in user:
+            student = User.objects.get(email=user, courseenrollment__course_id=course_id)
+        else:
+            student = User.objects.get(username=user, courseenrollment__course_id=course_id)
+        try:
+            certificate = GeneratedCertificate.objects.get(user=student, course_id=course_id)
+            certificate.status = status
+            certificate.save()
+            cert_saved_msg = (
+                u"""The certificate status for student {student_id}
+                in course '{course_id}'
+                has been set to '{status}'""".format(
+                    student_id=student.id,
+                    course_id=course_id,
+                    status=certificate.status,
+                )
+            )
+            LOGGER.info(cert_saved_msg)
+            # Print cert_saved_msg to sys.stdout, so that it is viewable in sysadmin
+            print(cert_saved_msg)
+        except GeneratedCertificate.DoesNotExist:
+            LOGGER.error(
+                (
+                    u"Certificate for student %d in course %s does not exist"
+                ),
+                student.id,
+                course_id,
+            )
+            raise

--- a/lms/static/js/sysadmin/mgmt_commands.js
+++ b/lms/static/js/sysadmin/mgmt_commands.js
@@ -8,14 +8,14 @@
                 {
                     'argument': 'add',
                     'display_name': gettext('username'),
-                    'required': true
+                    'required': true,
                 },
                 {
                     'argument': 'course_id',
                     'display_name': gettext('course_id'),
-                    'required': true
-                }
-            ]
+                    'required': true,
+                },
+            ],
         },
         {
             'display_name': gettext('De-whitelist a user'),
@@ -25,14 +25,14 @@
                 {
                     'argument': 'del',
                     'display_name': gettext('username'),
-                    'required': true
+                    'required': true,
                 },
                 {
                     'argument': 'course_id',
                     'display_name': gettext('course_id'),
-                    'required': true
-                }
-            ]
+                    'required': true,
+                },
+            ],
         },
         {
             'display_name': gettext('View user whitelist'),
@@ -42,9 +42,9 @@
                 {
                     'argument': 'course_id',
                     'display_name': gettext('course_id'),
-                    'required': true
-                }
-            ]
+                    'required': true,
+                },
+            ],
         },
         {
             'display_name': gettext('Generate a single certificate'),
@@ -54,27 +54,27 @@
                 {
                     'argument': 'course',
                     'display_name': gettext('course_id'),
-                    'required': true
+                    'required': true,
                 },
                 {
                     'argument': 'username',
                     'display_name': gettext('username'),
-                    'required': true
+                    'required': true,
                 },
                 {
                     'argument': 'grade_value',
                     'display_name': gettext('grade'),
-                    'required': false
+                    'required': false,
                 },
                 {
                     'argument': 'designation',
                     'display_name': gettext('designation'),
-                    'required': false
+                    'required': false,
                 },
                 {
                     'argument': 'template_file',
                     'display_name': gettext('template'),
-                    'required': false
+                    'required': false,
                 },
             ]
         },
@@ -152,13 +152,13 @@
             },
             error: function(std_ajax_err) {
               console.log('Management Command failed to execute');
-            }
+            },
         });
     }
 
     function generateInputRow(arg, type){
         var $inputRow = $(document.createElement('div'));
-        $inputRow.addClass('form-actions')
+        $inputRow.addClass('form-actions');
         var label = $(document.createElement('label'));
         label.html(arg.display_name);
         var input = $(document.createElement('input'));
@@ -202,10 +202,10 @@
 
     function loadCommand(command_key){
         var command = commands[command_key];
-        //update description
+        // update description
         $('#command-description').text(command.description);
 
-        //update form
+        // update form
         var $form_fieldset = $('#form-fieldset');
         $form_fieldset.html('');
         var legend = $(document.createElement('legend'));
@@ -237,8 +237,8 @@
         }
         var commandName = $(document.createElement('input'));
         commandName.attr({
-                type: 'hidden',
-                name: 'command'
+            type: 'hidden',
+            name: 'command',
         });
         commandName.val(command.method);
         $form_fieldset.append(commandName);

--- a/lms/static/js/sysadmin/mgmt_commands.js
+++ b/lms/static/js/sysadmin/mgmt_commands.js
@@ -78,6 +78,28 @@
                 },
             ]
         },
+        {
+            'display_name': gettext('Rescind a single certificate'),
+            'method': 'update_cert_status',
+            'description': gettext('Rescind a certificate for a particular user in a particular course'),
+            'kwargs': [
+                {
+                    'argument': 'course_id',
+                    'display_name': gettext('course_id'),
+                    'required': true,
+                },
+                {
+                    'argument': 'username_or_email',
+                    'display_name': gettext('username or email'),
+                    'required': true,
+                },
+                {
+                    'argument': 'status',
+                    'display_name': gettext('status'),
+                    'required': false,
+                },
+            ],
+        },
     ]
 
     function commandChanged(e){


### PR DESCRIPTION
Add update_cert_status management command
This commit adds a management command to update the status
of an exisitng cert. The command can be invoked from the
django management command-line interface or through the
sysadmin dashboard, through the  mgmt_commands section.
A suite of tests for this feature have been added and can
be run as follows:

python ./manage.py lms test --verbosity=1
lms/djangoapps/certificates/tests/test_cert_management.py:UpdateCertificateStatusTest
--traceback --settings=test