### PR TITLE
Enable Courses link to redirect to outside url

### DIFF
--- a/common/djangoapps/edxmako/shortcuts.py
+++ b/common/djangoapps/edxmako/shortcuts.py
@@ -51,7 +51,10 @@ def marketing_link(name):
     elif not enable_mktg_site and name in link_map:
         # don't try to reverse disabled marketing links
         if link_map[name] is not None:
-            return reverse(link_map[name])
+            if link_map[name].startswith('https://'):
+                return link_map[name]
+            else:
+                return reverse(link_map[name])
     else:
         log.debug("Cannot find corresponding link for name: %s", name)
         return '#'

--- a/common/djangoapps/edxmako/tests.py
+++ b/common/djangoapps/edxmako/tests.py
@@ -41,6 +41,20 @@ class ShortcutsTests(UrlResetMixin, TestCase):
             link = marketing_link('ABOUT')
             self.assertEquals(link, expected_link)
 
+    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @patch.dict('django.conf.settings.MKTG_URL_LINK_MAP', {'COURSES': 'courses'})
+    def test_marketing_link_internal_courses_url(self):
+        expected_link = reverse('courses')
+        link = marketing_link('COURSES')
+        self.assertEqual(link, expected_link)
+
+    @unittest.skipUnless(settings.ROOT_URLCONF == 'lms.urls', 'Test only valid in lms')
+    @patch.dict('django.conf.settings.MKTG_URL_LINK_MAP', {'COURSES': 'https://example.com'})
+    def test_marketing_link_external_courses_url(self):
+        expected_link = 'https://example.com'
+        link = marketing_link('COURSES')
+        self.assertEqual(link, expected_link)
+
     @ddt.data((True, None), (False, None))
     @ddt.unpack
     def test_edx_footer(self, expected_result, _):


### PR DESCRIPTION
@stvstnfrd modified marketing_link like we said and added a test to make sure that it returns the expected URL. is there a cleaner way to check the med school URL other than hard code it into the test?