### PR TITLE
Rename rescind cert command in sysadmin

### DIFF
--- a/lms/static/js/sysadmin/mgmt_commands.js
+++ b/lms/static/js/sysadmin/mgmt_commands.js
@@ -79,9 +79,9 @@
             ]
         },
         {
-            'display_name': gettext('Rescind a single certificate'),
+            'display_name': gettext('Update certificate status'),
             'method': 'update_cert_status',
-            'description': gettext('Rescind a certificate for a particular user in a particular course'),
+            'description': gettext('Update the status of a certificate for a particular user in a particular course'),
             'kwargs': [
                 {
                     'argument': 'course_id',
@@ -95,7 +95,7 @@
                 },
                 {
                     'argument': 'status',
-                    'display_name': gettext('status'),
+                    'display_name': gettext('status (defaults to `unavailable`)'),
                     'required': false,
                 },
             ],


### PR DESCRIPTION
This commit renames the `Rescind a single certificate` command
in the sysadmin dashboard to `Update certificate status`.