### PR TITLE
Add content visibility notice to Files & Uploads

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -76,6 +76,9 @@ FEATURES = {
     # email address for studio staff (eg to request course creation)
     'STUDIO_REQUEST_EMAIL': '',
 
+    # warning to instructors about publicly-viewable content
+    'CONTENT_VISIBILITY_NOTICE': True,
+
     # Segment - must explicitly turn it on for production
     'CMS_SEGMENT_KEY': None,
 
@@ -412,6 +415,7 @@ EMAIL_HOST_PASSWORD = ''
 DEFAULT_FROM_EMAIL = 'registration@example.com'
 DEFAULT_FEEDBACK_EMAIL = 'feedback@example.com'
 SERVER_EMAIL = 'devops@example.com'
+COPYRIGHT_EMAIL = 'copyright@example.com'
 ADMINS = ()
 MANAGERS = ADMINS
 

--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -51,6 +51,29 @@
 <div class="wrapper-content wrapper">
     <section class="content">
         <article class="content-primary" role="main">
+            % if settings.FEATURES.get('CONTENT_VISIBILITY_NOTICE',''):
+            <div id="content-visibility-notice">
+                <div class="wrapper wrapper-alert wrapper-alert-warning is-shown">
+                    <div class="alert warning ">
+                        <i class="feedback-symbol fa fa-warning"></i>
+                        <div class="copy">
+                            <h2 class="title" id="notice-title">Content Visibility Notice</h2>
+                            <p class="message">
+                              ${_("Materials uploaded here are viewable by the general public in addition "
+                              "to your registered Stanford students. Such publicly-viewable content is subject "
+                              "to copyright exemptions more restrictive than material viewable only by registered "
+                              "Stanford students. Therefore, before uploading any content that has not been "
+                              "created by you or content to which neither you nor Stanford owns all of the "
+                              "rights, you must obtain the permissions (releases, waivers, licenses, etc.) "
+                              "necessary to distribute such materials to the public through the Internet. "
+                              "If you have any questions, please send an email to "
+                              "{copyright_email}").format(copyright_email=settings.COPYRIGHT_EMAIL)}
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            % endif
             <div class="wrapper-assets" />
             <div class="ui-loading">
                 <p><span class="spin"><i class="icon fa fa-refresh"></i></span> <span class="copy">${_("Loading")}</span></p>


### PR DESCRIPTION
This commit adds the following message on the top of
the Files & Uploads page in Studio:
Materials uploaded here are viewable by the general public in addition
to your registered Stanford students. Such publicly-viewable content is subject
to copyright exemptions more restrictive than material viewable only by registered
Stanford students. Therefore, before uploading any content that has not been
created by you or content to which neither you nor Stanford owns all of the
rights, you must obtain the permissions (releases, waivers, licenses, etc.)
necessary to distribute such materials to the public through the Internet.
If you have any questions, please send an email to
copyright@stanfordonline.zendesk.com
![screen shot 2016-04-14 at 8 52 50 pm](https://cloud.githubusercontent.com/assets/1752973/14551225/1165fa9c-0285-11e6-8b90-9e2314bb9461.png)
