### PR TITLE
Update SHA for xblock-submit-and-compare

### DIFF
--- a/requirements/edx/stanford.txt
+++ b/requirements/edx/stanford.txt
@@ -5,6 +5,6 @@ xblock-image-modal==0.3.1
 -e git+https://github.com/Stanford-Online/xblock-grademe.git@v0.1.0#egg=grademebutton
 -e git+https://github.com/edx-solutions/xblock-ooyala.git@32d52edaa820dbdbf846d8a84f6bccbf0b9c8218#egg=xblock_ooyala_player-master
 -e git+https://github.com/Stanford-Online/DoneXBlock.git@0a38297377c262313b4677ec44deb9fac4db5afb#egg=done-xblock
--e git+https://github.com/Stanford-Online/xblock-submit-and-compare.git@2d5d0f7156ab35abe4bb3a51927cc447511b8d98#egg=xblock-submit-and-compare
+-e git+https://github.com/Stanford-Online/xblock-submit-and-compare.git@fcd305ec0f4ac6ecfad1721daeeeceeb2036556c#egg=xblock-submit-and-compare
 -e git+https://github.com/Stanford-Online/xblock-mufi.git@ee853b8a7668a87c27d13d55c0d149a04b8657b8#egg=xblock_mufi-master
 -e git+https://github.com/Stanford-Online/edx-analytics-data-api-client.git@1b8260ce8dd6edb999fffc46b09f77c83f87e1f9#egg=edx-analytics-data-api-client


### PR DESCRIPTION
This commit brings the Stanford dependency
on xblock-submit-and-compare to the most recent version.
The current version correctly supports the inclusion of
unicode characters into the hints section of the xblock.