### PR TITLE
Enable content library problems for metrics tab

### DIFF
--- a/lms/djangoapps/class_dashboard/tests/test_dashboard_data.py
+++ b/lms/djangoapps/class_dashboard/tests/test_dashboard_data.py
@@ -72,6 +72,19 @@ class TestGetProblemGradeDistribution(SharedModuleStoreTestCase):
                 cls.items.append(item)
                 cls.item = item
 
+            # Create embedded content library and problem
+            cls.content_library = ItemFactory.create(
+                parent_location=cls.unit.location,
+                category="library_content",
+            )
+            library_problem = ItemFactory.create(
+                parent_location=cls.content_library.location,
+                category="problem",
+                data=StringResponseXMLFactory().build_xml(answer='foo'),
+                display_name=u'test library problem',
+            )
+            cls.items.append(library_problem)
+
     def setUp(self):
         super(TestGetProblemGradeDistribution, self).setUp()
 
@@ -98,7 +111,7 @@ class TestGetProblemGradeDistribution(SharedModuleStoreTestCase):
             for j, user in enumerate(self.users):
                 StudentModuleFactory.create(
                     grade=1 if i < j else 0,
-                    max_grade=1 if i < j else 0.5,
+                    max_grade=1,
                     student=user,
                     course_id=self.course.id,
                     module_state_key=item.location,

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -2822,3 +2822,8 @@ STUDENT_RESPONSES_REPORT_SUPPORTED_TYPES = set([
     'submit-and-compare',
     'freetextresponse',
 ])
+
+# These types are children of children of units.
+TYPES_WITH_CHILD_PROBLEMS_LIST = [
+    'library_content',
+]


### PR DESCRIPTION
Problems imported from a content library have a different xmodule structure than regular problems. Changes were necessary to include these types.