### PR TITLE
Update SHA for xblock-submit-and-compare

### DIFF
--- a/requirements/edx/stanford.txt
+++ b/requirements/edx/stanford.txt
@@ -5,7 +5,7 @@ xblock-image-modal==0.3.1
 -e git+https://github.com/Stanford-Online/xblock-grademe.git@v0.1.0#egg=grademebutton
 -e git+https://github.com/edx-solutions/xblock-ooyala.git@32d52edaa820dbdbf846d8a84f6bccbf0b9c8218#egg=xblock_ooyala_player-master
 -e git+https://github.com/Stanford-Online/DoneXBlock.git@0a38297377c262313b4677ec44deb9fac4db5afb#egg=done-xblock
--e git+https://github.com/Stanford-Online/xblock-submit-and-compare.git@ac5a11ecd0ba487585a6d1b44b15517a1b796549#egg=xblock-submit-and-compare
+-e git+https://github.com/Stanford-Online/xblock-submit-and-compare.git@ee47aa24cb5b9206b1d02d69f7de07c53ad5d531#egg=xblock-submit-and-compare
 -e git+https://github.com/Stanford-Online/xblock-mufi.git@ee853b8a7668a87c27d13d55c0d149a04b8657b8#egg=xblock_mufi-master
 -e git+https://github.com/Stanford-Online/edx-analytics-data-api-client.git@1b8260ce8dd6edb999fffc46b09f77c83f87e1f9#egg=edx-analytics-data-api-client
 -e git+https://github.com/openlearninginitiative/xblock-inline-dropdown.git@0a540b87053756a9b3b497ef3aa3e4bd057b1fe2#egg=inline_dropdown


### PR DESCRIPTION
This commit brings the stanford dependency
on xblock-submit-and-compare to the most recent version.
The current version addresses an issue with request #6, by
properly setting the style of designated elements to
`display:none`