### PR TITLE
Update SHA for xblock-submit-and-compare

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -45,6 +45,7 @@ git+https://github.com/edx/nose.git@99c2aff0ff51bf228bfa5482e97e612c97a23245#egg
 -e git+https://github.com/edx/acid-block.git@e46f9cda8a03e121a00c7e347084d142d22ebfb7#egg=acid-xblock
 -e git+https://github.com/Stanford-Online/edx-ora2.git@af51177a6036634673ceaa00c1ee89f979a1fca0#egg=edx-ora2
 -e git+https://github.com/Stanford-Online/edx-submissions.git@c9c2881b864c5e16bb5dcbaed7a776d156ee98dc#egg=edx-submissions
+# Note: Stanford-Online's fork of xblock-submit-and-compare also depends on this exact version of opaque_keys:
 -e git+https://github.com/edx/opaque-keys.git@27dc382ea587483b1e3889a3d19cbd90b9023a06#egg=opaque-keys
 git+https://github.com/edx/ease.git@release-2015-07-14#egg=ease==0.1.3
 git+https://github.com/edx/i18n-tools.git@v0.1.3#egg=i18n-tools==v0.1.3

--- a/requirements/edx/stanford.txt
+++ b/requirements/edx/stanford.txt
@@ -5,7 +5,7 @@ xblock-image-modal==0.3.1
 -e git+https://github.com/Stanford-Online/xblock-grademe.git@v0.1.0#egg=grademebutton
 -e git+https://github.com/edx-solutions/xblock-ooyala.git@32d52edaa820dbdbf846d8a84f6bccbf0b9c8218#egg=xblock_ooyala_player-master
 -e git+https://github.com/Stanford-Online/DoneXBlock.git@0a38297377c262313b4677ec44deb9fac4db5afb#egg=done-xblock
--e git+https://github.com/Stanford-Online/xblock-submit-and-compare.git@ee47aa24cb5b9206b1d02d69f7de07c53ad5d531#egg=xblock-submit-and-compare
+-e git+https://github.com/Stanford-Online/xblock-submit-and-compare.git@04b7c85b16a8719c43c38dbdee7224f0dc92fe92#egg=xblock-submit-and-compare
 -e git+https://github.com/Stanford-Online/xblock-mufi.git@ee853b8a7668a87c27d13d55c0d149a04b8657b8#egg=xblock_mufi-master
 -e git+https://github.com/Stanford-Online/edx-analytics-data-api-client.git@1b8260ce8dd6edb999fffc46b09f77c83f87e1f9#egg=edx-analytics-data-api-client
 -e git+https://github.com/openlearninginitiative/xblock-inline-dropdown.git@0a540b87053756a9b3b497ef3aa3e4bd057b1fe2#egg=inline_dropdown


### PR DESCRIPTION
This PR: 
1) Adds a comment in github.txt to state that the dependency on opaque_keys 0.1.2 is shared by xblock
    submit-and-compare
2) Brings the edx-platform dependency on xblock-submit-and-compare to the most recent version.
    The version bump adds a tox dependency on opaque_keys 0.1.2, so that the version used by the test
     environment matches  the version used by Stanford-Online's fork of edx-platform