### PR TITLE
clarify account lockout message

### DIFF
--- a/cms/djangoapps/contentstore/tests/tests.py
+++ b/cms/djangoapps/contentstore/tests/tests.py
@@ -23,6 +23,8 @@ from pytz import UTC
 
 from freezegun import freeze_time
 
+from student.views import LOGIN_LOCKOUT_PERIOD_PLUS_FIVE_MINUTES
+
 
 class ContentStoreTestCase(ModuleStoreTestCase):
     def _login(self, email, password):
@@ -203,7 +205,13 @@ class AuthTestCase(ContentStoreTestCase):
             data = parse_json(resp)
             self.assertFalse(data['success'])
             self.assertIn(
-                'This account has been temporarily locked due to excessive login failures. Try again later.',
+                (
+                    "This account has been temporarily locked due to excessive login failures. "
+                    "Try again in {minutes} minute(s).  For security reasons, "
+                    "reseting the password will NOT lift the lockout. Please wait for {minutes} minute(s)."
+                ).format(
+                    minutes=LOGIN_LOCKOUT_PERIOD_PLUS_FIVE_MINUTES,
+                ),
                 data['value']
             )
 


### PR DESCRIPTION
Needed changes for testing:
1. lms/envs/devstack.py 
-FEATURES['ENABLE_MAX_FAILED_LOGIN_ATTEMPTS'] = True

Optional changes for testing:
1. lms/envs/private.py
-MAX_FAILED_LOGIN_ATTEMPTS_ALLOWED = 5 #lower for for testing, I used 5.
-MAX_FAILED_LOGIN_ATTEMPTS_LOCKOUT_PERIOD_SECS = 15 * 60 #lower for for testing, I used 15 * 1