### PR TITLE
Become teapot, short and stout

### DIFF
--- a/lms/static/js/student_account/views/LoginView.js
+++ b/lms/static/js/student_account/views/LoginView.js
@@ -102,6 +102,30 @@
             },
 
             saveError: function( error ) {
+                var url;
+                var queryParameters = (function getUrlVars() {
+                    // http://stackoverflow.com/a/4656873
+                    var vars = [], hash;
+                    var hashes = window.location.href.slice(window.location.href.indexOf('?') + 1).split('&');
+                    for(var i = 0; i < hashes.length; i++)
+                    {
+                        hash = hashes[i].split('=');
+                        vars.push(hash[0]);
+                        vars[hash[0]] = hash[1];
+                    }
+                    return vars;
+                }());
+                if(error.status === 418) {
+                    // Hijack the response for Shibboleth redirects
+                    url = error.responseText;
+                    if(url) {
+                        if(queryParameters['next']) {
+                            url = url + '?next=' + queryParameters['next'];
+                        }
+                        window.location = url;
+                        return;
+                    }
+                }
                 this.errors = ['<li>' + error.responseText + '</li>'];
                 this.setErrors();
                 this.element.hide( this.$resetSuccess );

--- a/openedx/core/djangoapps/user_api/helpers.py
+++ b/openedx/core/djangoapps/user_api/helpers.py
@@ -416,8 +416,16 @@ def shim_student_view(view_func, check_logged_in=False):
             msg = response_dict.get("value", u"")
             success = response_dict.get("success")
         except (ValueError, TypeError):
+            response_dict = {}
             msg = response.content
             success = True
+
+        redirect_url = response_dict.get('redirect')
+        if redirect_url == '/shib-login/':
+            # Hijack the response for Shibboleth redirects
+            response.status_code = 418
+            response.content = redirect_url
+            return response
 
         # If the user is not authenticated when we expect them to be
         # send the appropriate status code.

--- a/openedx/core/djangoapps/user_api/tests/test_helpers.py
+++ b/openedx/core/djangoapps/user_api/tests/test_helpers.py
@@ -186,6 +186,21 @@ class StudentViewShimTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, "")
 
+    def test_shib_redirect_from_json(self):
+        url = '/shib-login/'
+        view = self._shimmed_view(
+            HttpResponse(
+                status=418,
+                content=json.dumps({
+                    'success': True,
+                    'redirect': url,
+                }),
+            )
+        )
+        response = view(HttpRequest())
+        self.assertEqual(response.status_code, 418)
+        self.assertEqual(response.content, url)
+
     def test_error_from_json(self):
         view = self._shimmed_view(
             HttpResponse(content=json.dumps({

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -665,7 +665,7 @@ class LoginSessionViewTest(ApiTestCase):
                 "name": "password",
                 "defaultValue": "",
                 "type": "password",
-                "required": True,
+                "required": False,
                 "label": "Password",
                 "placeholder": "",
                 "instructions": "",

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -95,6 +95,7 @@ class LoginSessionView(APIView):
 
         form_desc.add_field(
             "password",
+            required=False,
             label=password_label,
             field_type="password",
             restrictions={


### PR DESCRIPTION
In-group, out-group, Shibboleth shout!

This seems to mostly work, so far.

I was able to follow through the code with some tracing statements on stage.
This revealed that attempting to sign in with a shib account did make it
most of the way through. It even generates a payload with redirect
information [1]. Sadly, this internal response is then dropped on the
floor [2].

From there, I tested on my devstack by hard-coding the aforementioned
payload [1]. As shib is not actually configured in development, I
couldn't get past the `/shib-login/` page, but I was routed there.

I'll need to put this on stage to verify the handoff to `/shib-login/`.
I don't know what, if any parameters may need passed along.

I did verify that attempting to enroll in a Shib-only course while
logged out will route you directly to web-auth and back again.

I have not tested registration via shib/web-auth.

[1] 
```json
{
    "redirect": "/shib-login/",
    "success": false
}
```
[2] https://github.com/stvstnfrd/edx-platform/blob/shib-logistration/openedx/core/djangoapps/user_api/helpers.py#L401