### PR TITLE
Fix typos in user log-in lockout message

### DIFF
--- a/cms/djangoapps/contentstore/tests/tests.py
+++ b/cms/djangoapps/contentstore/tests/tests.py
@@ -207,8 +207,8 @@ class AuthTestCase(ContentStoreTestCase):
             self.assertIn(
                 (
                     "This account has been temporarily locked due to excessive login failures. "
-                    "Try again in {minutes} minute(s).  For security reasons, "
-                    "reseting the password will NOT lift the lockout. Please wait for {minutes} minute(s)."
+                    "Try again in {minutes} minutes.  For security reasons, "
+                    "resetting the password will NOT lift the lockout. Please wait for {minutes} minutes."
                 ).format(
                     minutes=LOGIN_LOCKOUT_PERIOD_PLUS_FIVE_MINUTES,
                 ),

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -27,7 +27,7 @@ from django.db import IntegrityError, transaction
 from django.http import (HttpResponse, HttpResponseBadRequest, HttpResponseForbidden,
                          HttpResponseServerError, Http404)
 from django.shortcuts import redirect
-from django.utils.translation import ungettext
+from django.utils.translation import ungettext, ngettext
 from django.utils.http import base36_to_int
 from django.utils.translation import ugettext as _, get_language
 from django.views.decorators.csrf import csrf_exempt, ensure_csrf_cookie
@@ -1288,10 +1288,14 @@ def login_user(request, error=""):  # pylint: disable=too-many-statements,unused
         if LoginFailures.is_user_locked_out(user_found_by_email_lookup):
             return JsonResponse({
                 "success": False,
-                "value": _(
+                "value": ngettext(
                     "This account has been temporarily locked due to excessive login failures. "
-                    "Try again in {minutes} minute(s).  For security reasons, "
-                    "reseting the password will NOT lift the lockout. Please wait for {minutes} minute(s).").format(
+                    "Try again in {minutes} minute.  For security reasons, "
+                    "resetting the password will NOT lift the lockout. Please wait for {minutes} minute.",
+                    "This account has been temporarily locked due to excessive login failures. "
+                    "Try again in {minutes} minutes.  For security reasons, "
+                    "resetting the password will NOT lift the lockout. Please wait for {minutes} minutes.",
+                    LOGIN_LOCKOUT_PERIOD_PLUS_FIVE_MINUTES).format(
                         minutes=LOGIN_LOCKOUT_PERIOD_PLUS_FIVE_MINUTES,),
             })  # TODO: this should be status code 429  # pylint: disable=fixme
 


### PR DESCRIPTION
@caesar2164 @gbruhns @mondiaz

Please review PR for typos in account lockout message. [tello card](https://trello.com/c/KifpGSPq/350-belated-typo-in-lockout-messaging)

![screen shot 2016-07-05 at 2 41 01 pm](https://cloud.githubusercontent.com/assets/6748589/16622359/bdc83d04-434e-11e6-95c4-3fb7f3ca902f.png)

on local 
         $paver test
~30 Sass/Asset tests were failing for this branch, and any other branch I checked out?

The following is one error from one test running
        $paver test_lib -t pavelib/paver_tests/test_assets.py:TestPaverAssetTasks

![Uploading Screen Shot 2016-07-05 at 2.41.01 PM.png…]()
<img width="744" alt="screen shot 2016-07-06 at 8 02 00 am" src="https://cloud.githubusercontent.com/assets/6748589/16622732/fffaecac-434f-11e6-85be-2c1690eab7d6.png">