### PR TITLE
Allow shib account creation without requiring terms of service

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -1717,6 +1717,8 @@ def create_account_with_params(request, params):
             external_auth.views.SHIBBOLETH_DOMAIN_PREFIX
         )
     )
+    if not tos_required:
+        extra_fields.pop('terms_of_service', None)
 
     form = AccountCreationForm(
         data=params,


### PR DESCRIPTION
- Normal logistration uses terms_of_service in REGISTRATION_EXTRA_FIELDS
  but it needs to be removed for shib account creation that doesn't
  want it.

@stvstnfrd 