### PR TITLE
Sysadmin add progess tasks to kill table

### DIFF
--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -929,7 +929,10 @@ class TaskQueue(SysadminDashboardView):
         try:
             task = InstructorTask.objects.get(
                 id=row_id,
-                task_state='QUEUING',
+                task_state__in=[
+                    'QUEUING',
+                    'PROGRESS',
+                ],
             )
         except InstructorTask.DoesNotExist, err:
             msg = _('Cannot find task with ID {row_id} and task_state QUEUING - {error}').format(
@@ -950,7 +953,10 @@ class TaskQueue(SysadminDashboardView):
         data = []
 
         tasks = InstructorTask.objects.filter(
-            task_state='QUEUING',
+            task_state__in=[
+                'QUEUING',
+                'PROGRESS',
+            ],
         ).order_by('id').reverse()
         for task in tasks:
             data.append(
@@ -969,7 +975,7 @@ class TaskQueue(SysadminDashboardView):
                 _('Task Type'),
                 _('Task State'),
             ],
-            title=_('List of Queueing Tasks'),
+            title=_('List of Tasks'),
             data=data,
         )
 

--- a/lms/templates/sysadmin_dashboard.html
+++ b/lms/templates/sysadmin_dashboard.html
@@ -63,7 +63,7 @@ textarea {
       <a href="${reverse('sysadmin_staffing')}" class="${modeflag.get('staffing')}">${_('Staffing and Enrollment')}</a>
       ## Translators: refers to http://git-scm.com/docs/git-log
       <a href="${reverse('gitlogs')}">${_('Git Logs')}</a>
-      <a href="${reverse('sysadmin_task_queue')}" class="${modeflag.get('task_queue')}">${_('Task Queue')}</a>
+      <a href="${reverse('sysadmin_task_queue')}" class="${modeflag.get('task_queue')}">${_('Tasks')}</a>
       <a href="${reverse('sysadmin_mgmt_commands')}" class="${modeflag.get('mgmt_commands')}">${_('MGMT Commands')}</a>
     </h2>
 	<hr />
@@ -189,7 +189,7 @@ textarea {
 %endif
 
 %if modeflag.get('task_queue'):
-  <h3>${_('Kill Queuing Tasks')}</h3><br/>
+  <h3>${_('Kill Task')}</h3><br/>
 
   <form name="action" method="POST">
     <input type="hidden" name="csrfmiddlewaretoken" value="${ csrf_token }" />


### PR DESCRIPTION
@dcadams @stvstnfrd @caesar2164 Please review PR for including 'Progress' task state alongside 'Queuing' in the sysadmin 'Instructor Task' tab.  Previously only Queue state tasks could be found and killed in the 'Queuing Task' tab.  Now Progress tasks are included in the query and are available in the table.  The kill submission function needed to be updated to allow killing progress task also.