### PR TITLE
Display unobtrusive component locations in studio

### DIFF
--- a/cms/static/sass/elements/_xblocks.scss
+++ b/cms/static/sass/elements/_xblocks.scss
@@ -493,12 +493,31 @@
     }
   }
 
-  .component-id-footer {
-    .component-id-container {
-      padding: 5px 20px;
+  .location-footer {
+    .location-container {
+      position: relative;
       background: #f9f9f9;
       border-top: 1px solid #ddd;
+      border-bottom-left-radius: 3px;
+      border-bottom-right-radius: 3px;
       text-align: right;
+
+      .location-label {
+        .location-label-text {
+          position: absolute;
+          padding: 10px;
+          border-right: 1px solid #ddd;
+          z-index: 11;
+        }
+        .location-value {
+          width: 100%;
+          padding: 10px 10px 10px 80px;
+          border: none;
+          background: none;
+          box-shadow: none;
+          z-index: 10;
+        }
+      }
     }
   }
 }

--- a/cms/static/sass/elements/_xblocks.scss
+++ b/cms/static/sass/elements/_xblocks.scss
@@ -492,6 +492,15 @@
       }
     }
   }
+
+  .component-id-footer {
+    .component-id-container {
+      padding: 5px 20px;
+      background: #f9f9f9;
+      border-top: 1px solid #ddd;
+      text-align: right;
+    }
+  }
 }
 
 // +Editing - Xblocks

--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -142,10 +142,11 @@ messages = xblock.validate().to_json()
         <article class="xblock-render">
         ${content}
         </article>
-        <footer class="component-id-footer">
-            <div class="component-id-container">
-                <label>${_('Component ID:')}
-                    <span>${ xblock.location.block_id }</span>
+        <footer class="location-footer">
+            <div class="location-container">
+                <label class="location-label">
+                    <span class="location-label-text">${_('Location:')}</span>
+                    <input class="location-value" type="text" value="${ xblock.location }" disabled />
                 </label>
             </div>
         </footer>

--- a/cms/templates/studio_xblock_wrapper.html
+++ b/cms/templates/studio_xblock_wrapper.html
@@ -142,6 +142,13 @@ messages = xblock.validate().to_json()
         <article class="xblock-render">
         ${content}
         </article>
+        <footer class="component-id-footer">
+            <div class="component-id-container">
+                <label>${_('Component ID:')}
+                    <span>${ xblock.location.block_id }</span>
+                </label>
+            </div>
+        </footer>
     % else:
         <div class="xblock-message-area">
         ${content}


### PR DESCRIPTION
Obtaining the location/component ID of things is quite difficult in Open edX

these IDs are necessary for things like:
- Running Problem Report in the instructor tab/data downloads page
- constructing LTI content addresses
- xblocks that ask for component IDs to do their magic (ie: conditional/flow control & in-video quiz)

@stvstnfrd & @caseylitton

@Stanford-Online/openedx-courseops