### PR TITLE
Supporting certifcates custom field through an advanced setting field

### DIFF
--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -94,6 +94,10 @@ class CourseMetadata(object):
         if not settings.FEATURES.get('CUSTOM_COURSES_EDX'):
             filtered_list.append('enable_ccx')
 
+        # Do not show credits if feature is not enabled.
+        if not settings.FEATURES.get('ENABLE_CUSTOM_FIELDS_ON_CERTIFICATES'):
+            filtered_list.append('credits')
+
         return filtered_list
 
     @classmethod

--- a/common/lib/xmodule/xmodule/course_module.py
+++ b/common/lib/xmodule/xmodule/course_module.py
@@ -982,6 +982,13 @@ class CourseFields(object):
         scope=Scope.settings
     )
 
+    credits = String(
+        display_name=_("Course credits number"),
+        help=_("Enter course credits number that will appear in certificates"),
+        default=None,
+        scope=Scope.settings,
+    )
+
 
 class CourseModule(CourseFields, SequenceModule):  # pylint: disable=abstract-method
     """

--- a/lms/djangoapps/certificates/queue.py
+++ b/lms/djangoapps/certificates/queue.py
@@ -270,6 +270,7 @@ class XQueueCertInterface(object):
             mode_is_verified = enrollment_mode in GeneratedCertificate.VERIFIED_CERTS_MODES
             user_is_verified = SoftwareSecurePhotoVerification.user_is_verified(student)
             cert_mode = enrollment_mode
+            course_credits = course.credits or ''
 
             # For credit mode generate verified certificate
             if cert_mode == CourseMode.CREDIT_MODE:
@@ -359,6 +360,8 @@ class XQueueCertInterface(object):
                         'template_pdf': template_pdf,
                         'designation': designation,
                     }
+                    if settings.FEATURES.get('ENABLE_CUSTOM_FIELDS_ON_CERTIFICATES'):
+                        contents['course_credits'] = course_credits
                     if template_file:
                         contents['template_pdf'] = template_file
                     if generate_pdf:


### PR DESCRIPTION
## [CME1](https://docs.google.com/document/d/1q4M39uZW2M27nyPYAKKIewp4Xj5lffEdhoddVIzdNFE/edit?ts=57d2edbe#bookmark=id.ae6ppq1t52z9)
### Description

This PR supports adding a custom certificate field "Course Credits Number" on Studio. This field will be passed to certificate generator only when this feature is turn on.

Another PR on openedx-certificates will be the one in charge of using "Course Credits Number" to generate corresponding pdf certificate.
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @stvstnfrd
- [ ] Code review: @felipemontoya
### Devops assistance

To activate this feature there must be a "FEATURES['ENABLE_CUSTOM_FIELDS_ON_CERTIFICATES'] = True" on lms/envs/aws.py and cms/envs/aws.py

FYI: Tag anyone who might be interested in this PR here

@juancamilom
### Post-review
- [ ] Rebase and squash commits
