### PR TITLE
Fix sysadmin regenerate user certificate command

### DIFF
--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -19,6 +19,7 @@ from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
 from django.core.paginator import Paginator, PageNotAnInteger, EmptyPage
 from django.core.management import call_command
+from django.db import transaction
 from django.db import IntegrityError
 from django.http import HttpResponse, Http404
 from django.utils.decorators import method_decorator
@@ -810,6 +811,12 @@ class MgmtCommands(SysadminDashboardView):
     """
     Render views for management commands
     """
+
+    # This decorator is for the regenerate_user command, but affects all sysadmin
+    # management commands
+    @transaction.non_atomic_requests
+    def dispatch(self, *args, **kwargs):
+        return super(MgmtCommands, self).dispatch(*args, **kwargs)
 
     def get(self, request):
         """

--- a/lms/static/js/sysadmin/mgmt_commands.js
+++ b/lms/static/js/sysadmin/mgmt_commands.js
@@ -1,4 +1,7 @@
 (function () {
+    // If new commands are added here that modify the database, be sure to check
+    // expected behavior in error cases, since the backend handles these as
+    // non_atomic_requests (specifically to work with the regenerate_user command)
     var commands = [
         {
             'display_name': gettext('Whitelist a user'),
@@ -47,6 +50,8 @@
             ],
         },
         {
+            // If this command is removed from the sysadmin, the non_atomic_requests decorator can be removed
+            // from the backend dispatch() method
             'display_name': gettext('Generate a single certificate'),
             'method': 'regenerate_user',
             'description': gettext('Put a request on the queue to recreate the certificate for a particular user in a particular course'),


### PR DESCRIPTION
Use @transaction.non_atomic_requests since the command calls grade
which manages transactions itself. Affects all sysadmin management
commands, so make sure new commands added to sysadmin behave as
expected in error cases.

@stvstnfrd @caesar2164 