### PR TITLE
Supporting upgrade from a free course track to a paid course track

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -508,7 +508,7 @@ def complete_course_mode_info(course_id, enrollment, modes=None):
     if modes is None:
         modes = CourseMode.modes_for_course_dict(course_id)
 
-    mode_info = {'show_upsell': False, 'days_for_upsell': None}
+    mode_info = {'show_upsell': False, 'days_for_upsell': None, 'verified_upsell': False}
     # we want to know if the user is already enrolled as verified or credit and
     # if verified is an option.
     if CourseMode.VERIFIED in modes and enrollment.mode in CourseMode.UPSELL_TO_VERIFIED_MODES:
@@ -517,6 +517,18 @@ def complete_course_mode_info(course_id, enrollment, modes=None):
         if modes['verified'].expiration_datetime:
             today = datetime.datetime.now(UTC).date()
             mode_info['days_for_upsell'] = (modes['verified'].expiration_datetime.date() - today).days
+        mode_info['verified_upsell'] = True
+
+    if settings.FEATURES.get('USE_CME_UPGRADE_COURSE_TRACK'):
+        # we check if there is no-id-professional mode available
+        # if that's the case, prefer upsell for this mode
+        if CourseMode.NO_ID_PROFESSIONAL_MODE in modes and enrollment.mode in CourseMode.UPSELL_TO_VERIFIED_MODES:
+            mode_info['show_upsell'] = True
+            # if there is an expiration date, find out how long from now it is
+            if modes['no-id-professional'].expiration_datetime:
+                today = datetime.datetime.now(UTC).date()
+                mode_info['days_for_upsell'] = (modes['no-id-professional'].expiration_datetime.date() - today).days
+            mode_info['verified_upsell'] = False
 
     return mode_info
 

--- a/common/templates/course_modes/choose.html
+++ b/common/templates/course_modes/choose.html
@@ -135,6 +135,41 @@ from django.core.urlresolvers import reverse
                             </div>
                         % endif
 
+                        % if settings.FEATURES.get('USE_CME_UPGRADE_COURSE_TRACK') and "no-id-professional" in modes:
+                            <div class="register-choice register-choice-certificate">
+                                <div class="wrapper-copy">
+                                    <span class="deco-ribbon"></span>
+                                    <h4 class="title">${_("Pursue a CME Certificate")}</h4>
+                                    <div class="copy">
+                                        <p>${_("Highlight your new knowledge and skills with a CME certificate. Use this valuable credential to improve your job prospects and advance your career, or highlight your certificate in school applications.")}</p>
+                                        <p>
+                                            <div class="wrapper-copy-inline">
+                                                <div class="copy-inline">
+                                                    <h4>${_("Benefits of a CME Certificate")}</h4>
+                                                    <ul>
+                                                        <li>${_("{b_start}Official: {b_end}Receive an instructor-signed certificate with the institution's logo").format(**b_tag_kwargs)}</li>
+                                                        <li>${_("{b_start}Easily shareable: {b_end}Add the certificate to your CV or resume, or post it directly on LinkedIn").format(**b_tag_kwargs)}</li>
+                                                        <li>${_("{b_start}Motivating: {b_end}Give yourself an additional incentive to complete the course").format(**b_tag_kwargs)}</li>
+                                                        % if settings.FEATURES.get('IS_EDX_DOMAIN', False):
+                                                        <li>${_("{b_start}Support our Mission: {b_end} EdX, a non-profit, relies on verified certificates to help fund free education for everyone globally").format(**b_tag_kwargs)}</li>
+                                                        % endif
+                                                    </ul>
+                                                </div>
+                                                <div class="copy-inline list-actions">
+                                                    <ul class="list-actions">
+                                                        <li class="action action-select">
+                                                            <input type="hidden" name="contribution" value="${min_price}" />
+                                                            <input type="submit" name="no_id_pro_mode" value="${_('Pursue a CME Certificate')} ($${min_price} USD)" />
+                                                        </li>
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+                        % endif
+
                         % if "honor" in modes:
                             <span class="deco-divider">
                                 <span class="copy">${_("or")}</span>

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -317,6 +317,7 @@ from student.helpers import (
           <div class="message message-upsell has-actions is-shown">
 
             <div class="wrapper-extended">
+              % if course_mode_info['verified_upsell']:
                 <p class="message-copy" align="justify">
                   <b class="message-copy-bold">
                     ${_("Pursue a {cert_name_long} to highlight the knowledge and skills you gain in this course.").format(cert_name_long=cert_name_long)}
@@ -331,6 +332,22 @@ from student.helpers import (
                     </span>
                   </a>
                 </div>
+              % elif settings.FEATURES.get('USE_CME_UPGRADE_COURSE_TRACK') and not course_mode_info['verified_upsell']:
+                <p class="message-copy" align="justify">
+                  <b class="message-copy-bold">
+                    ${_("Pursue a {cert_name_long} to highlight the knowledge and skills you gain in this course.").format(cert_name_long=cert_name_long)}
+                  </b><br>
+                    ${_("It's official. It's easily shareable. It's a proven motivator to complete the course.")}
+                </p>
+                <div class="action-upgrade-container">
+                  <a class="action action-upgrade" href="${reverse('verify_student_start_flow', kwargs={'course_id': unicode(course_overview.id)})}" data-course-id="${course_overview.id | h}" data-user="${user.username | h}">
+                      <i class="action-upgrade-icon"></i>
+                    <span class="wrapper-copy">
+                      <span class="copy">${_("Upgrade to XXXXX")}</span>
+                    </span>
+                  </a>
+                </div>
+              % endif:
             </div>
           </div>
         %endif


### PR DESCRIPTION
## [CME8](https://docs.google.com/document/d/1q4M39uZW2M27nyPYAKKIewp4Xj5lffEdhoddVIzdNFE/edit?ts=57d2edbe#bookmark=id.2w6d0x0yz3i)
### Description

This PR supports a course track upgrade for LMS students. When feature flag is on, "no-id-professional" course mode will behave almost as "verified" mode of edx-platform. The difference lies in the fact that there is no need of verify identities for students.
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] Code review: @stvstnfrd
- [ ] Code review: @felipemontoya
### Devops assistance

To activate this feature there must be a `FEATURES[USE_CME_UPGRADE_COURSE_TRACK'] = True` on  lms/envs/aws.py.
It is recomended to use "honor" course mode and "no-id-professional" mode whenever this feature is on.

FYI: Tag anyone who might be interested in this PR here

@juancamilom
### Post-review
- [ ] Rebase and squash commits
