### PR TITLE
Bump django to v1.8.15

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -31,7 +31,7 @@ django-method-override==0.1.0
 # We need a fix to DRF 3.2.x, for now use it from our own cherry-picked repo
 #djangorestframework>=3.1,<3.2
 git+https://github.com/edx/django-rest-framework.git@3c72cb5ee5baebc4328947371195eae2077197b0#egg=djangorestframework==3.2.3
-django==1.8.7
+django==1.8.15
 edx-rest-api-client==1.2.1
 elasticsearch==0.4.5
 facebook-sdk==0.4.0


### PR DESCRIPTION
References:
[1] https://www.djangoproject.com/weblog/2016/sep/26/security-releases/
[2] https://docs.djangoproject.com/en/1.10/releases/1.8.15/
[3] https://github.com/edx/edx-platform/pull/13598