### PR TITLE
Supporting Help tab links customization.

### DIFF
--- a/lms/templates/help-center-link.html
+++ b/lms/templates/help-center-link.html
@@ -1,0 +1,9 @@
+<%!
+    from django.utils.translation import ugettext as _
+%>
+
+<li>
+    <a class="help-modal-button" href="https://stanfordonline.zendesk.com/hc" target="_blank">
+        ${_('Access the Help Center')}
+    </a>
+</li>

--- a/lms/templates/help-contact-link.html
+++ b/lms/templates/help-contact-link.html
@@ -1,0 +1,12 @@
+<%!
+    from django.utils.translation import ugettext as _
+    from microsite_configuration.templatetags.microsite import platform_name
+%>
+
+<p>
+    ${_("Can't find an answer to your question? You can contact the {platform_name} general support team directly {link_start}by clicking here{link_end}.").format(
+        platform_name=platform_name(),
+        link_start='<a href="#" id="feedback_link_question">',
+        link_end='</a>',
+      )}
+</p>

--- a/lms/templates/help_modal.html
+++ b/lms/templates/help_modal.html
@@ -56,18 +56,12 @@ from student.models import UserProfile
     <p>${_('Have <strong>general questions about {platform_name}</strong>? You can find lots of helpful information in the {platform_name} Help Center.').format(platform_name=platform_name())}</p>
 	
 	<ul class="help-buttons">
-	  <li><a class="help-modal-button" href="https://stanfordonline.zendesk.com/hc" target="_blank">
-		${_('Access the Help Center')}
-	  </a></li>
+	  <%include file="help-center-link.html" />
 	</ul>
 
 	<hr>
 % if course:
-    <p>${_("Can't find an answer to your question? You can contact the {platform_name} general support team directly {link_start}by clicking here{link_end}.").format(
-        platform_name=platform_name(),
-        link_start='<a href="#" id="feedback_link_question">',
-        link_end='</a>',
-      )}</p>
+    <%include file="help-contact-link.html" />
 
     <p class="note">${_('Please note: The {platform_name} support team is English speaking. While we will do our best to address your inquiry in any language, our responses will be in English.').format(
         platform_name=platform_name()


### PR DESCRIPTION
## [CME7](https://docs.google.com/document/d/1q4M39uZW2M27nyPYAKKIewp4Xj5lffEdhoddVIzdNFE/edit?ts=57d2edbe#bookmark=id.i4bbzubzbnvh)
### Description

This PR supports the corresponding CME theme [feature](https://github.com/Stanford-Online/cme-theme/pull/6).
### Reviewers

If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [x] Code review: @stvstnfrd
- [x] Code review: @felipemontoya
### Devops assistance

In order to change help modal links for CME edx-platform instance, the following configuration changes must be applied.

```
EDXAPP_HELP_MODAL_LINKS:
  - 'url': 'https://support.zoho.com/portal/stanfordonlinecmesupport/newticket'
    'text': 'Submit new ticket'
  - 'url': 'https://support.zoho.com/portal/stanfordonlinecmesupport/signin#myarea'
    'text': 'My tickets'

```

FYI: Tag anyone who might be interested in this PR here

@juancamilom
### Post-review
- [x] Rebase and squash commits
