### PR TITLE
Fix UndefinedContext exception seen on stage with OLI handler.

### DIFF
--- a/common/djangoapps/track/backends/oli.py
+++ b/common/djangoapps/track/backends/oli.py
@@ -164,7 +164,7 @@ class OLIAnalyticsBackend(BaseBackend):
             return None
 
         if isinstance(descriptor, CapaDescriptor):
-            problem_text = descriptor.lcp.problem_text
+            problem_text = descriptor.data
             return problem_text
         else:
             return None


### PR DESCRIPTION
Previous code was throwing an UndefinedContext on stage but not in devstack.

This change is such that the x_module code throwing the exception is not called.