### PR TITLE
Update submit and compare SHA in order to add mobile app support.

### DIFF
--- a/requirements/edx/stanford.txt
+++ b/requirements/edx/stanford.txt
@@ -4,7 +4,7 @@ xblock-image-modal==0.3.1
 -e git+https://github.com/Stanford-Online/xblock-free-text-response@6349ab4425818c40e7e603b88953bdf7d869bf50#egg=xblock-free-text-response
 -e git+https://github.com/Stanford-Online/xblock-grademe.git@v0.1.0#egg=grademebutton
 -e git+https://github.com/edx-solutions/xblock-ooyala.git@32d52edaa820dbdbf846d8a84f6bccbf0b9c8218#egg=xblock_ooyala_player-master
--e git+https://github.com/Stanford-Online/xblock-submit-and-compare.git@d5234416c52f58ff63b4b47105a638d9347cf5e2#egg=xblock-submit-and-compare
+-e git+https://github.com/Stanford-Online/xblock-submit-and-compare.git@86906db85b804b9f1762f75de6c1582eb6c819f6#egg=xblock-submit-and-compare
 -e git+https://github.com/Stanford-Online/xblock-mufi.git@ee853b8a7668a87c27d13d55c0d149a04b8657b8#egg=xblock_mufi-master
 -e git+https://github.com/Stanford-Online/edx-analytics-data-api-client.git@1b8260ce8dd6edb999fffc46b09f77c83f87e1f9#egg=edx-analytics-data-api-client
 -e git+https://github.com/openlearninginitiative/xblock-inline-dropdown.git@d4b3630838f8df0f2d3706128366650d3b0f158b#egg=inline_dropdown


### PR DESCRIPTION
I updated the SHA in the `stanford.txt` requirements file in order to point to the last [commit](https://github.com/Stanford-Online/xblock-submit-and-compare/commit/86906db85b804b9f1762f75de6c1582eb6c819f6) of the _xblock-submit-and-compare_ which is including the code that solves the compatibility issues with the mobile app.
See [this](https://github.com/Stanford-Online/xblock-submit-and-compare/commit/c3f9b6a6117e6ff77df24695b6815f03bd03b1ba) for details about the mobile app fix.

@stvstnfrd @caesar2164 @caseylitton 