### PR TITLE
Make filmstrip tooltip appear on top

### DIFF
--- a/lms/static/sass/_stanford.scss
+++ b/lms/static/sass/_stanford.scss
@@ -13,3 +13,12 @@
         margin: 5% !important;
     }
 }
+
+#course-content {
+    .sequence {
+       .sequence-nav {
+           // Make sure tooltip is above
+           z-index: 100;
+       }
+    }
+}


### PR DESCRIPTION
Set z-index to 100 to force tooltip to the top. This supersedes PR in lagunita-theme, https://github.com/Stanford-Online/lagunita-theme/pull/45

@caesar2164 @stvstnfrd