### PR TITLE
Modify CME registration options & remove "other"

### DIFF
--- a/common/djangoapps/cme_registration/models.py
+++ b/common/djangoapps/cme_registration/models.py
@@ -92,11 +92,11 @@ class CmeUserProfile(UserProfile):
     sub_specialty = models.CharField(blank=True, null=True, max_length=255)
 
     AFFILIATION_CHOICES = (('Stanford Children\'s Health', 'Stanford Children\'s Health'),
-                           ('Packard Children\'s Health Alliance', 'Packard Children\'s Health Alliance'),
+                           ('Packard Children\'s Health Alliance (PCHA)', 'Packard Children\'s Health Alliance (PCHA)'),
                            ('Stanford Health Care', 'Stanford Health Care'),
                            ('Stanford University', 'Stanford University'),
-                           ('University Healthcare Alliance', 'University Healthcare Alliance'),
-                           ('Other', 'Other'),
+                           ('University Healthcare Alliance (UHA)', 'University Healthcare Alliance (UHA)'),
+                           ('Not affiliated with Stanford Medicine', 'Not affiliated with Stanford Medicine'),
                            )
     affiliation = models.CharField(blank=True, null=True, max_length=46, choices=AFFILIATION_CHOICES)
     other_affiliation = models.CharField(blank=True, null=True, max_length=46)

--- a/common/djangoapps/cme_registration/tests/registration_tests.py
+++ b/common/djangoapps/cme_registration/tests/registration_tests.py
@@ -53,7 +53,6 @@ class TestCmeRegistration(UrlResetMixin, TestCase):
                           'specialty': 'specialty',
                           'sub_specialty': 'sub_specialty',
                           'affiliation': 'affiliation',
-                          'other_affiliation': 'other_affiliation',
                           'sub_affiliation': 'sub_affiliation',
                           'sunet_id': 'sunet_id',
                           'stanford_department': 'stanford_department',
@@ -383,8 +382,7 @@ class TestCmeRegistration(UrlResetMixin, TestCase):
 
         self.post_vars['specialty'] = 'Other/None'
         self.post_vars['sub_specialty'] = 'Other/None'
-        self.post_vars['affiliation'] = 'Other'
-        self.post_vars['other_affiliation'] = 'other_affiliation'
+        self.post_vars['affiliation'] = 'Not affiliated with Stanford Medicine'
         self.post_vars['sub_affiliation'] = ''
 
         url = reverse('create_account')
@@ -414,8 +412,7 @@ class TestCmeRegistration(UrlResetMixin, TestCase):
                                                          license_state='license_state',
                                                          physician_status='physician_status',
                                                          patient_population='patient_population',
-                                                         affiliation='Other',
-                                                         other_affiliation='other_affiliation',
+                                                         affiliation='Not affiliated with Stanford Medicine',
                                                          sub_affiliation='',
                                                          sunet_id='sunet_id',
                                                          stanford_department='stanford_department',

--- a/common/djangoapps/cme_registration/views.py
+++ b/common/djangoapps/cme_registration/views.py
@@ -234,10 +234,7 @@ def _do_cme_create_account(post_vars):
     cme_user_profile.sub_specialty = post_vars.get('sub_specialty')
     cme_user_profile.affiliation = post_vars.get('affiliation')
 
-    if post_vars.get('affiliation') == 'Other':
-        cme_user_profile.other_affiliation = post_vars.get('other_affiliation')
-    else:
-        cme_user_profile.other_affiliation = None
+    cme_user_profile.other_affiliation = None
 
     cme_user_profile.sub_affiliation = post_vars.get('sub_affiliation')
     cme_user_profile.sunet_id = post_vars.get('sunet_id')

--- a/lms/templates/cme_register.html
+++ b/lms/templates/cme_register.html
@@ -45,13 +45,11 @@
         
         if ($(this).children("option:selected").val() === 'Stanford University') {
           $(this).siblings('.affiliation-controlled#sunet_id_container, .affiliation-controlled#stanford_department_container').slideDown('fast');
-        } else if ($(this).children("option:selected").val() === "Packard Children's Health Alliance") {
+        } else if ($(this).children("option:selected").val() === "Packard Children's Health Alliance (PCHA)") {
           $(this).siblings('.affiliation-controlled#PCHA_affiliation_container').slideDown('fast');
-        } else if ($(this).children("option:selected").val() === 'University Healthcare Alliance') {
+        } else if ($(this).children("option:selected").val() === 'University Healthcare Alliance (UHA)') {
           $(this).siblings('.affiliation-controlled#UHA_affiliation_container').slideDown('fast');
-        } else if ($(this).children("option:selected").val() === 'Other') {
-          $(this).siblings('.affiliation-controlled#other_affiliation_container').slideDown('fast');
-        }
+        } 
       });
       
      
@@ -480,11 +478,6 @@
                   <option value="${code}">${UHA_affiliation}</option>
                 %endfor
               </select>
-            </div>
-           
-            <div class="field affiliation-controlled" id="other_affiliation_container" style="display: none;">
-              <br />
-              <input id="other_affiliation" type="text" name="other_affiliation" title="Please enter your affiliation here." placeholder="Please enter your affiliation here." />
             </div>
           </li>
           


### PR DESCRIPTION
Changed two affiliation names. Removed option to select "other"
as an affiliation, and removed validation for the free response field.
Modified js in the cme_register.html file to
omit scrolling animation that reveals a text field when "other" is
selected as affiliation. Since users can no longer submit "other" as an affiliation with a
free-response value, we remove validation for the other_affiliation
post variable.

replaces https://github.com/Stanford-Online/edx-platform/pull/573