### PR TITLE
Fix mongo forum params to handle multiple host:port pairs

### DIFF
--- a/lms/djangoapps/django_comment_client/management_utils.py
+++ b/lms/djangoapps/django_comment_client/management_utils.py
@@ -12,7 +12,7 @@ MONGO_PARAMS = settings.FORUM_MONGO_PARAMS
 
 def get_mongo_connection_string():
     """
-    Creates the a URI which contains the appropriate credentials needed to access MongoDB using MongoClient
+    Creates a URI which contains the appropriate credentials needed to access MongoDB using MongoClient
     :return: a string representing the URI which can be used to create a MongoClient instance.
     """
     credentials = ''
@@ -26,10 +26,18 @@ def get_mongo_connection_string():
                 user=MONGO_PARAMS['user'],
                 password=MONGO_PARAMS['password'],
             )
-    connection_string = "mongodb://" + credentials + "{host}:{port}/{database}".format(
-        host=MONGO_PARAMS['host'],
-        port=MONGO_PARAMS['port'],
+    hosts = [
+        "{host}:{port}".format(
+            host=host['host'],
+            port=host['port'],
+        )
+        for host in MONGO_PARAMS['hosts']
+    ]
+    hosts = ','.join(hosts)
+    connection_string = "mongodb://{credentials}{hosts}/{database}".format(
+        credentials=credentials,
         database=MONGO_PARAMS['database'],
+        hosts=hosts,
     )
     return connection_string
 

--- a/openedx/stanford/lms/envs/common.py
+++ b/openedx/stanford/lms/envs/common.py
@@ -37,8 +37,12 @@ FEATURES.update({
     'SEND_USERS_EMAILADDR_WITH_CODERESPONSE': False,
 })
 FORUM_MONGO_PARAMS = {
-    'host': 'localhost',
-    'port': 27017,
+    'hosts': [
+        {
+            'host': 'localhost',
+            'port': 27017,
+        },
+    ],
     'password': '',
     'user': '',
     'database': 'forum',


### PR DESCRIPTION
Modifies get_mongo_connection_string() to convert multiple host:port pairs into appropriate connection string
Modifies example forum params: instead of having a single "host" value and a single "port" value, params now includes a "hosts" array of host-port objects.