### PR TITLE
Fix video speed issues (Firefox and Safari)

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
@@ -450,7 +450,7 @@ function (VideoPlayer) {
                     state.speed = '2.0';
                     state.videoPlayer.onPlay();
                     expect(state.videoPlayer.setPlaybackRate)
-                        .toHaveBeenCalledWith('2.0', true);
+                        .toHaveBeenCalledWith('2.0');
                     state.videoPlayer.onPlay();
                     expect(state.videoPlayer.setPlaybackRate.calls.length)
                         .toEqual(1);
@@ -974,9 +974,8 @@ function (VideoPlayer) {
                 state.isHtml5Mode.andReturn(false);
                 state.videoPlayer.isPlaying.andReturn(true);
                 VideoPlayer.prototype.setPlaybackRate.call(state, '0.75');
-                expect(state.videoPlayer.updatePlayTime).toHaveBeenCalledWith(60);
-                expect(state.videoPlayer.player.loadVideoById)
-                    .toHaveBeenCalledWith('videoId', 60);
+                expect(state.videoPlayer.player.setPlaybackRate)
+                    .toHaveBeenCalledWith('0.75');
             });
 
             it('in Flash mode and video not started', function () {
@@ -984,15 +983,7 @@ function (VideoPlayer) {
                 state.isHtml5Mode.andReturn(false);
                 state.videoPlayer.isPlaying.andReturn(false);
                 VideoPlayer.prototype.setPlaybackRate.call(state, '0.75');
-                expect(state.videoPlayer.updatePlayTime).toHaveBeenCalledWith(60);
-                expect(state.videoPlayer.seekTo).toHaveBeenCalledWith(60);
-                expect(state.trigger).toHaveBeenCalledWith(
-                    'videoProgressSlider.updateStartEndTimeRegion',
-                    {
-                        duration: 60
-                    });
-                expect(state.videoPlayer.player.cueVideoById)
-                    .toHaveBeenCalledWith('videoId', 60);
+                expect(state.videoPlayer.player.setPlaybackRate).toHaveBeenCalledWith('0.75');
             });
 
             it('in HTML5 mode', function () {
@@ -1006,9 +997,7 @@ function (VideoPlayer) {
 
                 state.videoPlayer.isPlaying.andReturn(false);
                 VideoPlayer.prototype.setPlaybackRate.call(state, '1.0');
-                expect(state.videoPlayer.updatePlayTime).toHaveBeenCalledWith(60);
-                expect(state.videoPlayer.player.cueVideoById)
-                    .toHaveBeenCalledWith('videoId', 60);
+                expect(state.videoPlayer.player.setPlaybackRate).toHaveBeenCalledWith('1.0');
             });
         });
     });

--- a/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
+++ b/common/lib/xmodule/xmodule/js/src/video/03_video_player.js
@@ -107,17 +107,7 @@ function (HTML5Video, Resizer) {
         // starts playing. Just after that configurations can be applied.
         state.videoPlayer.ready = _.once(function () {
             if (!state.isFlashMode() && state.speed != '1.0') {
-
-                // Work around a bug in the Youtube API that causes videos to
-                // play at normal speed rather than at the configured speed in
-                // Safari.  Setting the playback rate to 1.0 *after* playing
-                // started and then to the actual value tricks the player into
-                // picking up the speed setting.
-                if (state.browserIsSafari && state.isYoutubeType()) {
-                    state.videoPlayer.setPlaybackRate(1.0, false);
-                }
-
-                state.videoPlayer.setPlaybackRate(state.speed, true);
+                state.videoPlayer.setPlaybackRate(state.speed);
             }
         });
 
@@ -382,73 +372,8 @@ function (HTML5Video, Resizer) {
         }
     }
 
-    function setPlaybackRate(newSpeed, useCueVideoById) {
-        var duration = this.videoPlayer.duration(),
-            time = this.videoPlayer.currentTime,
-            methodName, youtubeId;
-
-        // There is a bug which prevents YouTube API to correctly set the speed
-        // to 1.0 from another speed in Firefox when in HTML5 mode. There is a
-        // fix which basically reloads the video at speed 1.0 when this change
-        // is requested (instead of simply requesting a speed change to 1.0).
-        // This has to be done only when the video is being watched in Firefox.
-        // We need to figure out what browser is currently executing this code.
-        //
-        // TODO: Check the status of
-        // http://code.google.com/p/gdata-issues/issues/detail?id=4654
-        // When the YouTube team fixes the API bug, we can remove this
-        // temporary bug fix.
-
-        // If useCueVideoById is true it will reload video again.
-        // Used useCueVideoById to fix the issue video not playing if we change
-        // the speed before playing the video.
-        if (
-          this.isHtml5Mode() && !(this.browserIsFirefox &&
-          (useCueVideoById || newSpeed === '1.0') && this.isYoutubeType())
-        ) {
-            this.videoPlayer.player.setPlaybackRate(newSpeed);
-        } else {
-            // We request the reloading of the video in the case when YouTube
-            // is in Flash player mode, or when we are in Firefox, and the new
-            // speed is 1.0. The second case is necessary to avoid the bug
-            // where in Firefox speed switching to 1.0 in HTML5 player mode is
-            // handled incorrectly by YouTube API.
-            methodName = 'cueVideoById';
-            youtubeId = this.youtubeId(newSpeed);
-
-            if (this.videoPlayer.isPlaying()) {
-                methodName = 'loadVideoById';
-            }
-
-            this.videoPlayer.player[methodName](youtubeId, time);
-
-            // We need to call play() explicitly because after the call
-            // to functions cueVideoById() followed by seekTo() the video
-            // is in a PAUSED state.
-            //
-            // Why? This is how the YouTube API is implemented.
-            // sjson.search() only works if time is defined.
-            if (!_.isUndefined(time)) {
-                this.videoPlayer.updatePlayTime(time, duration);
-            }
-            if (time > 0 && this.isFlashMode()) {
-                this.videoPlayer.seekTo(time);
-                this.trigger(
-                    'videoProgressSlider.updateStartEndTimeRegion',
-                    {
-                        duration: duration
-                    }
-                );
-            }
-            // In Html5 mode if video speed is changed before playing in firefox and
-            // changed speed is not '1.0' then manually trigger setPlaybackRate method.
-            // In browsers other than firefox like safari user can set speed to '1.0'
-            // if its not already set to '1.0' so in that case we don't have to
-            // call 'setPlaybackRate'
-            if (this.isHtml5Mode() && newSpeed != '1.0') {
-                this.videoPlayer.player.setPlaybackRate(newSpeed);
-            }
-        }
+    function setPlaybackRate(newSpeed) {
+        this.videoPlayer.player.setPlaybackRate(newSpeed);
     }
 
     function onSpeedChange(newSpeed) {


### PR DESCRIPTION
Youtube API previously had issues with video speed; different bugs in each of Firefox and Safari. Previous code included workarounds to these issues that are no longer needed and that, in one case, were causing the bugs they claimed to fix. @stvstnfrd @caesar2164 @caseylitton 