### PR TITLE
Change course navigation z-index

### DIFF
--- a/lms/static/sass/_stanford.scss
+++ b/lms/static/sass/_stanford.scss
@@ -18,7 +18,7 @@
     .sequence {
        .sequence-nav {
            // Make sure tooltip is above
-           z-index: 100;
+           z-index: 10;
        }
     }
 }


### PR DESCRIPTION
Fixes issue with header drop-down appearing below course
navigation bar on page. @stvstnfrd @caesar2164 