### PR TITLE
Update xblocks SHAs to add mobile support

### DIFF
--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -90,7 +90,7 @@ git+https://github.com/edx/edx-oauth2-provider.git@0.5.8#egg=edx-oauth2-provider
 git+https://github.com/edx/edx-val.git@0.0.9#egg=edxval==0.0.9
 -e git+https://github.com/pmitros/RecommenderXBlock.git@518234bc354edbfc2651b9e534ddb54f96080779#egg=recommender-xblock
 -e git+https://github.com/pmitros/RateXBlock.git@367e19c0f6eac8a5f002fd0f1559555f8e74bfff#egg=rate-xblock
--e git+https://github.com/Stanford-Online/DoneXBlock.git@81f3439eaaa6535a82c081f99b998b9595354a31#egg=done-xblock
+-e git+https://github.com/Stanford-Online/DoneXBlock.git@20a8e94460efca992f98a0aef8c970ccf5997ef4#egg=done-xblock
 git+https://github.com/edx/edx-milestones.git@v0.1.8#egg=edx-milestones==0.1.8
 git+https://github.com/edx/edx-lint.git@v0.4.1#egg=edx_lint==0.4.1
 git+https://github.com/edx/xblock-utils.git@v1.0.2#egg=xblock-utils==1.0.2

--- a/requirements/edx/stanford.txt
+++ b/requirements/edx/stanford.txt
@@ -1,14 +1,14 @@
-xblock-image-modal==0.3.1
+xblock-image-modal==0.4.0 
 -e git+https://github.com/openlearninginitiative/xblock-image-coding.git@cee23e3d59943066159ca13839c82a12d9ccf749#egg=xblock_image_coding
--e git+https://github.com/Stanford-Online/xblock-qualtrics-survey@701788bd1a81ef6d97dd5ef6b5c35998266c62a5#egg=xblock-qualtrics-survey
+-e git+https://github.com/Stanford-Online/xblock-qualtrics-survey@08899b3927a52218b8d42f2c2e98789ccef97faf#egg=xblock-qualtrics-survey
 -e git+https://github.com/Stanford-Online/xblock-free-text-response@d9b446186fda1f657fec9a7a9b61ea3c58f35fcc#egg=xblock-free-text-response
--e git+https://github.com/Stanford-Online/xblock-grademe.git@v0.1.0#egg=grademebutton
+-e git+https://github.com/Stanford-Online/xblock-grademe.git@v0.1.1#egg=grademebutton
 -e git+https://github.com/edx-solutions/xblock-ooyala.git@32d52edaa820dbdbf846d8a84f6bccbf0b9c8218#egg=xblock_ooyala_player-master
 -e git+https://github.com/Stanford-Online/xblock-submit-and-compare.git@428b0d0ec12f80a049d0edb166214adff07eb07b#egg=xblock-submit-and-compare
 -e git+https://github.com/Stanford-Online/xblock-mufi.git@ee853b8a7668a87c27d13d55c0d149a04b8657b8#egg=xblock_mufi-master
 -e git+https://github.com/Stanford-Online/edx-analytics-data-api-client.git@1b8260ce8dd6edb999fffc46b09f77c83f87e1f9#egg=edx-analytics-data-api-client
 -e git+https://github.com/openlearninginitiative/xblock-inline-dropdown.git@d4d527211ac843cb490ac9c9a40b90de624001e1#egg=inline_dropdown
--e git+https://github.com/Stanford-Online/xblock-in-video-quiz.git@release/v0.1.2#egg=invideoquiz_xblock
+-e git+https://github.com/Stanford-Online/xblock-in-video-quiz.git@release/v0.1.3#egg=invideoquiz_xblock
 ubcpi-xblock==0.5.0
 -e git+https://github.com/Stanford-Online/XBlockStattutor.git@bbe80daabaaa73af72e0180609d903d9ea71cb37#egg=stattutor_xblock
 -e git+https://github.com/Stanford-Online/EdxAdaptXBlock.git@0dab829b2c9061e296be56d3ca7c8e027adcf362#egg=edxadapt-xblock


### PR DESCRIPTION
Since not all the xblocks are pulled in the same way from their github repositories, after a discussion with @stvstnfrd  we came up with the approach depicted below.
# Updated regolarly just by changing the SHA:
- [done-xblock](https://github.com/Stanford-Online/edx-platform/compare/master...libremente:master#diff-9280d61660044201fa35456d5ae4ee74L93 )
- [xblock-free-text-response](https://github.com/Stanford-Online/edx-platform/compare/master...libremente:master#diff-72862aac3381dc7c619e17db668d1b3fL4 )
- [xblock-qualtrics-survey](https://github.com/Stanford-Online/edx-platform/compare/master...libremente:master#diff-72862aac3381dc7c619e17db668d1b3fR3 )

# ~~Need review~~ Done
- [xblock-in-video-quiz](https://github.com/Stanford-Online/edx-platform/compare/master...libremente:master#diff-72862aac3381dc7c619e17db668d1b3fL11)
Previously it was pulling a specific version `release/v0.1.2` whilst now it is pointing to the latest commit. We think it's better to create a new release `v0.1.3` and then re-update this file in order to be consistent with the approach used before.
A note has been added in the file with a brief reminder.
**EDIT 2/27:** pulling correctly latest version.

- [xblock-grademe](https://github.com/Stanford-Online/edx-platform/compare/master...libremente:master#diff-72862aac3381dc7c619e17db668d1b3fL5 )
Same as before, previously `xblock-grademe.git@v0.1.0` version was pulled, now changed to the latest commit. Probably it's better to tag / create a new release and re-update this file.
**EDIT 2/27:** pulling correctly latest version.

# ~~To be done~~ Done

- [xblock-image-modal](https://github.com/Stanford-Online/edx-platform/compare/master...libremente:master#diff-72862aac3381dc7c619e17db668d1b3fL1)
This xblock has a different behavior since this package has to be submitted to PyPI to be correctly pulled. I did not change the version in the file but I've added a comment with a note. 
**Edit 2/27**: Latest commit fixes this.

- ~~xblocks-poll [(not changed in the file)](https://github.com/Stanford-Online/edx-platform/blob/master/requirements/edx/github.txt#L108)
The old SHA was pointing to a very old version of the module (https://github.com/open-craft/xblock-poll/commit/e7a6c95c300e95c51e42bfd1eba70489c05a6527). Since it seems that the xblock has been updated in the past two years (https://github.com/open-craft/xblock-poll/commits/master) does it make sense to merge from upstream and then add the mobile support or should we just add the mobile support to the version currently in use? Is this xblock in use? Steve said that _maybe_ it was installed for testing purposes only.~~
**EDIT 2/27**: will not update it here. 

Thank you!
@caesar2164 @caseylitton 
