### PR TITLE
Ensure that course_about uses a valid course key

### DIFF
--- a/lms/djangoapps/courseware/views.py
+++ b/lms/djangoapps/courseware/views.py
@@ -847,12 +847,11 @@ def get_cosmetic_display_price(course, registration_price):
 
 
 @ensure_csrf_cookie
+@ensure_valid_course_key
 @cache_if_anonymous()
 def course_about(request, course_id):
     """
     Display the course's about page.
-
-    Assumes the course_id is in a valid format.
     """
 
     course_key = SlashSeparatedCourseKey.from_deprecated_string(course_id)


### PR DESCRIPTION
In lms/djangoapps/courseware/views.py, the course_about() view method originally assumed that the course key had a valid format, whereas the corresponding tests in lms/djangoapps/courseware/tests/test_views.py (class VerifyCourseKeyDecoratorTests) wrap calls to course_about() with ensure_valid_course_key().

Therefore, it seemed as if the test was doing more work for the course_about() view than was actually being done in production. 

The simple solution here might be to add the @ensure_valid_course_key decorator to the course_about() view.

Note that the ensure_valid_course_key() decorator has not been logging relevant view requests involving invalid course keys up until now, and therefore, I did not add any logging to this PR as of now.