### PR TITLE
Improve performance of studio->lms link.

### DIFF
--- a/cms/djangoapps/contentstore/views/course.py
+++ b/cms/djangoapps/contentstore/views/course.py
@@ -22,6 +22,7 @@ from smtplib import SMTPException
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locations import Location
+from opaque_keys.edx.locations import SlashSeparatedCourseKey
 
 from .component import (
     ADVANCED_COMPONENT_TYPES,
@@ -692,13 +693,17 @@ def _remove_in_process_courses(courses, in_process_course_actions):
         """
         Return a dict of the data which the view requires for each course
         """
-        course_key = course.id
-        course_module = modulestore().get_course(course_key, depth=0)
+        if isinstance(course.id, SlashSeparatedCourseKey):
+            course_module = modulestore().get_course(course.id, depth=0)
+            lms_link = get_lms_link_for_item(course_module.location)
+        else:
+            lms_link = get_lms_link_for_item(course.location)
+
         return {
             'display_name': course.display_name,
             'course_key': unicode(course.location.course_key),
             'url': reverse_course_url('course_handler', course.id),
-            'lms_link': get_lms_link_for_item(course_module.location),
+            'lms_link': lms_link,
             'rerun_link': _get_rerun_link_for_item(course.id),
             'org': course.display_org_with_default,
             'number': course.display_number_with_default,


### PR DESCRIPTION
Improves performance by just retrieving non-split rather than all courses explicitly to build the lms_link. This should be a large improvement and will not get worse with time.

The is a bit of a band aid until the following commit can be pulled in from upstream:

https://github.com/edx/edx-platform/commit/b2572ee2b39103568940186771ca472235b97e64