### PR TITLE
Fix error saving fields XBlockSaveError

### DIFF
--- a/lms/djangoapps/courseware/user_state_client.py
+++ b/lms/djangoapps/courseware/user_state_client.py
@@ -196,15 +196,25 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
         evt_time = time()
 
         for usage_key, state in block_keys_to_state.items():
-            student_module, created = StudentModule.objects.get_or_create(
-                student=user,
-                course_id=usage_key.course_key,
-                module_state_key=usage_key,
-                defaults={
-                    'state': json.dumps(state),
-                    'module_type': usage_key.block_type,
-                },
-            )
+            try:
+                student_module, created = StudentModule.objects.get_or_create(
+                    student=user,
+                    course_id=usage_key.course_key,
+                    module_state_key=usage_key,
+                    defaults={
+                        'state': json.dumps(state),
+                        'module_type': usage_key.block_type,
+                    },
+                )
+            except IntegrityError:
+                # PLAT-1109 - Until we switch to read committed, we cannot rely
+                # on get_or_create to be able to see rows created in another
+                # process. This seems to happen frequently, and ignoring it is the
+                # best course of action for now
+                log.warning("set_many: IntegrityError for student {} - course_id {} - usage key {}".format(
+                    user, repr(unicode(usage_key.course_key)), usage_key
+                ))
+                return
 
             num_fields_before = num_fields_after = num_new_fields_set = len(state)
             num_fields_updated = 0


### PR DESCRIPTION
Suppress IntegrityErrors that may be caused by a race condition
between processes resulting from a slow-loading page and a user refreshing the
page. This should stop our nonstop "XBlockSaveError: Error saving fields []" issues.

Cherry-picked from upstream, see https://github.com/edx/edx-platform/pull/14128
Issue identified here: https://openedx.atlassian.net/browse/PLAT-1109

@stvstnfrd @caesar2164 