### PR TITLE
Clarify JSON CommentClientError with status code and url

### DIFF
--- a/lms/lib/comment_client/utils.py
+++ b/lms/lib/comment_client/utils.py
@@ -107,10 +107,18 @@ def perform_request(method, url, data_or_params=None, raw=False,
             try:
                 data = response.json()
             except ValueError:
+                message = (
+                    u"Comments service returned invalid JSON "
+                    "for request {request_id} at url {url} "
+                    "with HTTP status code {status_code}; "
+                    "first 100 characters: '{content}'"
+                )
                 raise CommentClientError(
-                    u"Comments service returned invalid JSON for request {request_id}; first 100 characters: '{content}'".format(
+                    message.format(
                         request_id=request_id,
-                        content=response.text[:100]
+                        url=response.url,
+                        status_code=response.status_code,
+                        content=response.text[:100],
                     )
                 )
             if paged_results:


### PR DESCRIPTION
Only added status code and url. Below is an example of a response and its attributes. Let me know if you think anything else would be helpful.

>>> response.__dict__

{'cookies': <<class 'requests.cookies.RequestsCookieJar'>[]>,

 '_content': '{"username":"staff","external_id":"5"}', 

'headers': {'content-length': '38', 'x-xss-protection': '1; mode=block', 'content-language': 'en-US', 'server': 'WEBrick/1.3.1 (Ruby/1.9.3/2013-06-27)', 'connection': 'Keep-Alive', 'date': 'Thu, 09 Mar 2017 20:33:39 GMT', 'x-frame-options': 'sameorigin', 'content-type': 'application/json;charset=utf-8'}, 

'url': u'http://localhost:18080/api/v1/users/5?request_id=029c19ae-4939-4632-ae4b-8c83b8fd82db', 

'status_code': 200,

 '_content_consumed': True, 

'encoding': 'utf-8',

'request': <PreparedRequest [GET]>, 

'connection': <requests.adapters.HTTPAdapter object at 0x96fa310>, 

'elapsed': datetime.timedelta(0, 0, 7036), 'raw': <requests.packages.urllib3.response.HTTPResponse object at 0x9810b10>, 

'reason': 'OK', 

'history': []}