### PR TITLE
Fix issue with LTI consumer error with adding vertical blocks

### DIFF
--- a/common/lib/xmodule/xmodule/vertical_block.py
+++ b/common/lib/xmodule/xmodule/vertical_block.py
@@ -55,8 +55,8 @@ class VerticalBlock(SequenceFields, XModuleFields, StudioEditableBlock, XmlParse
             'items': contents,
             'xblock_context': context,
             'show_bookmark_button': True,
-            'bookmarked': child_context['bookmarked'],
-            'bookmark_id': "{},{}".format(child_context['username'], unicode(self.location))
+            'bookmarked': child_context.get('bookmarked', False),
+            'bookmark_id': "{},{}".format(child_context.get('username', ''), unicode(self.location))
         }))
 
         fragment.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/vertical_student_view.js'))


### PR DESCRIPTION
While it was possible to embed sequentials and html blocks in consumers'
courses, the server would previously crash if an LTI consumer tried to
add a vertical to their page. This is because, when retrieving a vertical,
the server expected certain keys to exist in dicts; they wouldn't
if the request was made by an LTI consumer.

@stvstnfrd @caesar2164 