### PR TITLE
Change password reset message

### DIFF
--- a/lms/djangoapps/student_account/test/test_views.py
+++ b/lms/djangoapps/student_account/test/test_views.py
@@ -100,7 +100,7 @@ class StudentAccountUpdateTest(UrlResetMixin, TestCase):
             follow=True
         )
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Your password has been changed successfully")
+        self.assertContains(response, "Your password has been set.")
 
         # Log the user out to clear session data
         self.client.logout()

--- a/lms/djangoapps/student_account/test/test_views.py
+++ b/lms/djangoapps/student_account/test/test_views.py
@@ -100,7 +100,7 @@ class StudentAccountUpdateTest(UrlResetMixin, TestCase):
             follow=True
         )
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Your password has been set.")
+        self.assertContains(response, "Your password has been changed successfully")
 
         # Log the user out to clear session data
         self.client.logout()

--- a/lms/templates/registration/password_reset_complete.html
+++ b/lms/templates/registration/password_reset_complete.html
@@ -45,7 +45,7 @@
   <section class="passwordreset container">
     {% block content %}
     <section role="main" class="content">
-      {% trans "Your password has been changed successfully. You are now logged in." %}
+      {% trans "Your password has been set. You are now logged in." %}
     </section>
     {% endblock %}
   </section>

--- a/lms/templates/registration/password_reset_complete.html
+++ b/lms/templates/registration/password_reset_complete.html
@@ -45,9 +45,7 @@
   <section class="passwordreset container">
     {% block content %}
     <section role="main" class="content">
-      {% blocktrans with link_start='<a href="/login">' link_end='</a>' %}
-      Your password has been set.  You may go ahead and {{ link_start }}log in{{ link_end }} now.
-      {% endblocktrans %}
+      {% trans "Your password has been changed successfully. You are now logged in." %}
     </section>
     {% endblock %}
   </section>

--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -333,7 +333,13 @@ class RegistrationView(APIView):
         try:
             user = create_account_with_params(request, data)
         except AccountValidationError as err:
-            errors = { err.field: [{"user_message": err.message}] }
+            errors = {
+                err.field: [
+                    {
+                        'user_message': err.message,
+                    }
+                ]
+            }
             return JsonResponse(errors, status=409)
         except ValidationError as err:
             # Should only get non-field errors from this function


### PR DESCRIPTION
Previous message asked user to log in, but they were already logged in.
Chose to simply change message instead of immediate redirect to dashboard as that seems
to be the standard after a brief review of different sites.