### PR TITLE
Add missing requirement for CME report

### DIFF
--- a/requirements/edx/stanford.txt
+++ b/requirements/edx/stanford.txt
@@ -1,3 +1,4 @@
+unidecode
 xblock-image-modal==0.4.0 
 -e git+https://github.com/openlearninginitiative/xblock-image-coding.git@cee23e3d59943066159ca13839c82a12d9ccf749#egg=xblock_image_coding
 -e git+https://github.com/Stanford-Online/xblock-qualtrics-survey@d112b1dc2e2a8e7138da4e11e5c7ae68dc63ae18#egg=xblock-qualtrics-survey


### PR DESCRIPTION
It looks like this was just never added when the import was inserted.
If I had to guess, I'd say Dylan just installed this manually into the
virtualenv when he set up that task :\