### PR TITLE
Split Stanford-only AUTHORS into separate file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -156,7 +156,6 @@ Johnny Brown <johnnybrown7@gmail.com>
 Ben McMorran <bmcmorran@edx.org>
 Mat Peterson <mpeterson@edx.org>
 Tim Babych <tim.babych@gmail.com>
-Se Won Jang <swjang@stanford.edu>
 Brandon DeRosier <btd@cheesekeg.com>
 Daniel Li <swli@edx.org>
 Daniel Friedman <dfriedman@edx.org>
@@ -209,7 +208,6 @@ Phil McGachey <phil_mcgachey@harvard.edu>
 Sri Harsha Pamu <kmitharsha@gmail.com>
 Cris Ewing <cris@crisewing.com>
 Carlos de La Guardia <carlos@jazkarta.com>
-Albert Liang <albertliangcode@gmail.com>
 Amir Qayyum Khan <amir.qayyum@arbisoft.com>
 Jolyon Bloomfield <jolyon@mit.edu>
 Kyle McCormick <kylemccor@gmail.com>

--- a/openedx/stanford/AUTHORS
+++ b/openedx/stanford/AUTHORS
@@ -1,0 +1,1 @@
+Se Won Jang <swjang@stanford.edu>


### PR DESCRIPTION
Interestingly, Albert was in there twice for some reason.

Se Won only merged code to our origin, not upstream,
hence moving his name.

TODO:
- [ ] Backport other Stanford team members here (eventually)?