### PR TITLE
Fix wonky tests from hinting

### DIFF
--- a/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
+++ b/cms/djangoapps/contentstore/features/component_settings_editor_helpers.py
@@ -59,12 +59,12 @@ def click_new_component_button(step, component_button_css):
 
 
 def _click_advanced():
-    css = 'ul.problem-type-tabs a[href="#tab3"]'
+    css = 'ul.problem-type-tabs a[href="#tab2"]'
     world.css_click(css)
 
     # Wait for the advanced tab items to be displayed
-    tab3_css = 'div.ui-tabs-panel#tab3'
-    world.wait_for_visible(tab3_css)
+    tab2_css = 'div.ui-tabs-panel#tab2'
+    world.wait_for_visible(tab2_css)
 
 
 def _find_matching_button(category, component_type):


### PR DESCRIPTION
This was introduced back in 2014 as part of Nick Parlante's Custom
Hinting/Feedback work.

We've run into some issues with this over the years.
- It was PR'ed upstream, but we pre-emptively cherry-picked it back to
  our remote before waiting for an upstream merge.
- As a consequence, we must have resolved some conflicts incorrectly or
  ran into some other issues.

This referred to a non-existent tab when adding new components.
- Add New Component
- Problem
- See: Common Problem Types and Advanced

Since this 3rd tab hasn't existed for more than a year,
I don't know what it was doing :\