### PR TITLE
Unfork course rerun tests

### DIFF
--- a/cms/djangoapps/contentstore/tests/test_contentstore.py
+++ b/cms/djangoapps/contentstore/tests/test_contentstore.py
@@ -15,7 +15,6 @@ from path import Path as path
 from textwrap import dedent
 from uuid import uuid4
 from functools import wraps
-from unittest import skipUnless
 from unittest import SkipTest
 
 from django.conf import settings
@@ -1942,7 +1941,6 @@ class RerunCourseTest(ContentStoreTestCase):
         rerun_of_rerun_course_key = self.post_rerun_request(rerun_course_key, rerun_of_rerun_data)
         self.verify_rerun_course(rerun_course_key, rerun_of_rerun_course_key, rerun_of_rerun_data['display_name'])
 
-    @skipUnless(settings.FEATURES.get('ALLOW_COURSE_RERUNS'), 'Course reruns not enabled')
     def test_rerun_course_fail_no_source_course(self):
         existent_course_key = CourseFactory.create().id
         non_existent_course_key = CourseLocator("org", "non_existent_course", "non_existent_run")

--- a/openedx/stanford/cms/envs/test.py
+++ b/openedx/stanford/cms/envs/test.py
@@ -1,6 +1,7 @@
 from cms.envs.test import *
 
 
+FEATURES['ALLOW_COURSE_RERUNS'] = True
 # Remove sneakpeek during tests to prevent unwanted redirect
 MIDDLEWARE_CLASSES = tuple([
     mwc for mwc in MIDDLEWARE_CLASSES


### PR DESCRIPTION
While edX enables course reruns by default, we disable it on all of our
instances. Instead of forking the tests to accomodate, we should instead
enable the feature during tests.  The added benefit here is that this
ensures that we continue testing the feature, even though we aren't
(currently) using it.