### PR TITLE
Add free text response xblock to OPTIONAL_APPS

### DIFF
--- a/openedx/stanford/cms/envs/common.py
+++ b/openedx/stanford/cms/envs/common.py
@@ -46,6 +46,10 @@ MIDDLEWARE_CLASSES += (
     # Log out sneakpeek users
     'sneakpeek.middleware.SneakPeekLogoutMiddleware',
 )
+OPTIONAL_APPS += (
+    # Added here to allow translations
+    'freetextresponse',
+)
 SHIB_ONLY_SITE = False
 SHIB_REDIRECT_DOMAIN_WHITELIST = {}
 SPLIT_STUDIO_HOME = False

--- a/openedx/stanford/lms/envs/common.py
+++ b/openedx/stanford/lms/envs/common.py
@@ -69,6 +69,10 @@ MAX_ENROLLEES_FOR_METRICS_USING_DB = 100
 MIDDLEWARE_CLASSES += (
     'sneakpeek_deeplink.middleware.SneakPeekDeepLinkMiddleware',
 )
+OPTIONAL_APPS += (
+    # Added here to allow translations
+    'freetextresponse',
+)
 ORA2_RESPONSES_DOWNLOAD = {
     'STORAGE_TYPE': 'localfs',
     'BUCKET': 'edx-grades',


### PR DESCRIPTION
@stvstnfrd @kluo @caesar2164 PR for platform change for vi translation updates to free text response.

Adding xblocks to OPTIONAL_APPS or INSTALLED_APPS
is need for xblock translations to function properly.