### PR TITLE
Update xblock free text to version 0.1.4

### DIFF
--- a/requirements/edx/stanford.txt
+++ b/requirements/edx/stanford.txt
@@ -2,7 +2,7 @@ unidecode
 xblock-image-modal==0.4.0 
 -e git+https://github.com/openlearninginitiative/xblock-image-coding.git@cee23e3d59943066159ca13839c82a12d9ccf749#egg=xblock_image_coding
 -e git+https://github.com/Stanford-Online/xblock-qualtrics-survey@d112b1dc2e2a8e7138da4e11e5c7ae68dc63ae18#egg=xblock-qualtrics-survey
--e git+https://github.com/Stanford-Online/xblock-free-text-response@release/v0.1.3#egg=xblock-free-text-response
+-e git+https://github.com/Stanford-Online/xblock-free-text-response@release/v0.1.4#egg=xblock-free-text-response
 -e git+https://github.com/Stanford-Online/xblock-grademe.git@v0.1.1#egg=grademebutton
 -e git+https://github.com/edx-solutions/xblock-ooyala.git@32d52edaa820dbdbf846d8a84f6bccbf0b9c8218#egg=xblock_ooyala_player-master
 -e git+https://github.com/Stanford-Online/xblock-submit-and-compare.git@428b0d0ec12f80a049d0edb166214adff07eb07b#egg=xblock-submit-and-compare


### PR DESCRIPTION
@dcadams @caesar2164 PR to update free text xblock to version 0.1.4.

This fixes the html tags in studio setting prompt text box issue created in version 0.1.3 when we switched to django templates.