### PR TITLE
Show answer button config

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -105,7 +105,6 @@ class CapaFields(object):
         scope=Scope.user_state)
     max_attempts = Integer(
         display_name=_("Maximum Attempts"),
-        #default=float('inf'),
         help=_(
             'Defines the number of times a student can try to answer this problem. '
             'If the value is not set, infinite attempts are allowed. '
@@ -139,14 +138,14 @@ class CapaFields(object):
             {"display_name": _("Correct or Past Due"), "value": SHOWANSWER.CORRECT_OR_PAST_DUE},
             {"display_name": _("Past Due"), "value": SHOWANSWER.PAST_DUE},
             {"display_name": _("Never"), "value": SHOWANSWER.NEVER},
-            {"display_name": _("After # Attempts"), "value": SHOWANSWER.AFTER_ATTEMPTS}]
+            {"display_name": _("After Some Number of Attempts"), "value": SHOWANSWER.AFTER_SOME_NUMBER_OF_ATTEMPTS}]
     )
     attempts_before_showanswer_button = Integer(
         display_name=_("Show Answer After Attempts"),
         help=_("Number of times the student must attempt answering the question before the Show Answer button appears."),
         values={"min": 0},
         default=0,
-        scope=Scope.settings
+        scope=Scope.settings,
     )
     force_save_button = Boolean(
         help=_("Whether to force the save button to appear on the page"),
@@ -908,15 +907,14 @@ class CapaMixin(CapaFields):
             return self.is_correct() or self.is_past_due()
         elif self.showanswer == SHOWANSWER.PAST_DUE:
             return self.is_past_due()
-        elif self.showanswer == SHOWANSWER.AFTER_ATTEMPTS:
-            # self.attempts_before_showanswer_button is read_only, to
-            # work with its modified value, we make a copy.
+        elif self.showanswer == SHOWANSWER.AFTER_SOME_NUMBER_OF_ATTEMPTS:
             required_attempts = self.attempts_before_showanswer_button
             if self.max_attempts and required_attempts >= self.max_attempts:
                 required_attempts = self.max_attempts
             return self.attempts >= required_attempts
         elif self.showanswer == SHOWANSWER.ALWAYS:
             return True
+
         return False
 
     def update_score(self, data):

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -143,7 +143,7 @@ class CapaFields(object):
     attempts_before_showanswer_button = Integer(
         display_name=_("Show Answer - Attempts"),
         help=_("Number of times the student must attempt answering the question before the Show Answer button appears."),
-        values={"min":0},
+        values={"min": 0},
         default=0,
         scope=Scope.settings
     )
@@ -908,7 +908,7 @@ class CapaMixin(CapaFields):
         elif self.showanswer == SHOWANSWER.PAST_DUE:
             return self.is_past_due()
         elif self.showanswer == SHOWANSWER.AFTER_ATTEMPTS:
-            return self.attempts >= self.attempts_before_showanswer_button 
+            return self.attempts >= self.attempts_before_showanswer_button
         elif self.showanswer == SHOWANSWER.ALWAYS:
             return True
 

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -137,7 +137,8 @@ class CapaFields(object):
             {"display_name": _("Finished"), "value": SHOWANSWER.FINISHED},
             {"display_name": _("Correct or Past Due"), "value": SHOWANSWER.CORRECT_OR_PAST_DUE},
             {"display_name": _("Past Due"), "value": SHOWANSWER.PAST_DUE},
-            {"display_name": _("Never"), "value": SHOWANSWER.NEVER}]
+            {"display_name": _("Never"), "value": SHOWANSWER.NEVER},
+            {"display_name": _("Attempted X Times"), "value": SHOWANSWER.ATTEMPTED_X_TIMES}]
     )
     force_save_button = Boolean(
         help=_("Whether to force the save button to appear on the page"),

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -138,7 +138,8 @@ class CapaFields(object):
             {"display_name": _("Correct or Past Due"), "value": SHOWANSWER.CORRECT_OR_PAST_DUE},
             {"display_name": _("Past Due"), "value": SHOWANSWER.PAST_DUE},
             {"display_name": _("Never"), "value": SHOWANSWER.NEVER},
-            {"display_name": _("After Some Number of Attempts"), "value": SHOWANSWER.AFTER_SOME_NUMBER_OF_ATTEMPTS}]
+            {"display_name": _("After Some Number of Attempts"), "value": SHOWANSWER.AFTER_SOME_NUMBER_OF_ATTEMPTS},
+        ]
     )
     attempts_before_showanswer_button = Integer(
         display_name=_("Show Answer: Number of Attempts"),

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -138,7 +138,13 @@ class CapaFields(object):
             {"display_name": _("Correct or Past Due"), "value": SHOWANSWER.CORRECT_OR_PAST_DUE},
             {"display_name": _("Past Due"), "value": SHOWANSWER.PAST_DUE},
             {"display_name": _("Never"), "value": SHOWANSWER.NEVER},
-            {"display_name": _("Attempted X Times"), "value": SHOWANSWER.ATTEMPTED_X_TIMES}]
+            {"display_name": _("After X Attempts"), "value": SHOWANSWER.AFTER_X_ATTEMPTS}]
+    )
+    attempts_before_showanswer_button = Integer(
+        display_name=_("Value of X"),
+        help=_("Number of times the student must attempt answering the question before the Show Answer button appears."),
+        values={"min":0},
+        scope=Scope.settings
     )
     force_save_button = Boolean(
         help=_("Whether to force the save button to appear on the page"),
@@ -900,6 +906,8 @@ class CapaMixin(CapaFields):
             return self.is_correct() or self.is_past_due()
         elif self.showanswer == SHOWANSWER.PAST_DUE:
             return self.is_past_due()
+        elif self.showanswer == SHOWANSWER.AFTER_X_ATTEMPTS:
+            return self.attempts > self.attempts_before_showanswer_button 
         elif self.showanswer == SHOWANSWER.ALWAYS:
             return True
 

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -915,7 +915,6 @@ class CapaMixin(CapaFields):
             if self.max_attempts and required_attempts >= self.max_attempts:
                 required_attempts = self.max_attempts
             return self.attempts >= required_attempts
-        
         elif self.showanswer == SHOWANSWER.ALWAYS:
             return True
         return False

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -138,10 +138,10 @@ class CapaFields(object):
             {"display_name": _("Correct or Past Due"), "value": SHOWANSWER.CORRECT_OR_PAST_DUE},
             {"display_name": _("Past Due"), "value": SHOWANSWER.PAST_DUE},
             {"display_name": _("Never"), "value": SHOWANSWER.NEVER},
-            {"display_name": _("After X Attempts"), "value": SHOWANSWER.AFTER_X_ATTEMPTS}]
+            {"display_name": _("After # Attempts"), "value": SHOWANSWER.AFTER_ATTEMPTS}]
     )
     attempts_before_showanswer_button = Integer(
-        display_name=_("Value of X"),
+        display_name=_("Show Answer - Attempts"),
         help=_("Number of times the student must attempt answering the question before the Show Answer button appears."),
         values={"min":0},
         default=0,
@@ -907,7 +907,7 @@ class CapaMixin(CapaFields):
             return self.is_correct() or self.is_past_due()
         elif self.showanswer == SHOWANSWER.PAST_DUE:
             return self.is_past_due()
-        elif self.showanswer == SHOWANSWER.AFTER_X_ATTEMPTS:
+        elif self.showanswer == SHOWANSWER.AFTER_ATTEMPTS:
             return self.attempts >= self.attempts_before_showanswer_button 
         elif self.showanswer == SHOWANSWER.ALWAYS:
             return True

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -141,7 +141,7 @@ class CapaFields(object):
             {"display_name": _("After Some Number of Attempts"), "value": SHOWANSWER.AFTER_SOME_NUMBER_OF_ATTEMPTS}]
     )
     attempts_before_showanswer_button = Integer(
-        display_name=_("Show Answer After Attempts"),
+        display_name=_("Show Answer: Number of Attempts"),
         help=_("Number of times the student must attempt answering the question before the Show Answer button appears."),
         values={"min": 0},
         default=0,

--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -144,6 +144,7 @@ class CapaFields(object):
         display_name=_("Value of X"),
         help=_("Number of times the student must attempt answering the question before the Show Answer button appears."),
         values={"min":0},
+        default=0,
         scope=Scope.settings
     )
     force_save_button = Boolean(
@@ -907,7 +908,7 @@ class CapaMixin(CapaFields):
         elif self.showanswer == SHOWANSWER.PAST_DUE:
             return self.is_past_due()
         elif self.showanswer == SHOWANSWER.AFTER_X_ATTEMPTS:
-            return self.attempts > self.attempts_before_showanswer_button 
+            return self.attempts >= self.attempts_before_showanswer_button 
         elif self.showanswer == SHOWANSWER.ALWAYS:
             return True
 

--- a/common/lib/xmodule/xmodule/capa_base_constants.py
+++ b/common/lib/xmodule/xmodule/capa_base_constants.py
@@ -18,6 +18,7 @@ class SHOWANSWER(object):
     NEVER = "never"
     AFTER_ATTEMPTS = "after_attempts"
 
+
 class RANDOMIZATION(object):
     """
     Constants for problem randomization

--- a/common/lib/xmodule/xmodule/capa_base_constants.py
+++ b/common/lib/xmodule/xmodule/capa_base_constants.py
@@ -16,7 +16,7 @@ class SHOWANSWER(object):
     CORRECT_OR_PAST_DUE = "correct_or_past_due"
     PAST_DUE = "past_due"
     NEVER = "never"
-
+    ATTEMPTED_X_TIMES = "attempted_x_times"
 
 class RANDOMIZATION(object):
     """

--- a/common/lib/xmodule/xmodule/capa_base_constants.py
+++ b/common/lib/xmodule/xmodule/capa_base_constants.py
@@ -16,7 +16,7 @@ class SHOWANSWER(object):
     CORRECT_OR_PAST_DUE = "correct_or_past_due"
     PAST_DUE = "past_due"
     NEVER = "never"
-    ATTEMPTED_X_TIMES = "attempted_x_times"
+    AFTER_X_ATTEMPTS = "after_x_attempts"
 
 class RANDOMIZATION(object):
     """

--- a/common/lib/xmodule/xmodule/capa_base_constants.py
+++ b/common/lib/xmodule/xmodule/capa_base_constants.py
@@ -16,7 +16,7 @@ class SHOWANSWER(object):
     CORRECT_OR_PAST_DUE = "correct_or_past_due"
     PAST_DUE = "past_due"
     NEVER = "never"
-    AFTER_X_ATTEMPTS = "after_x_attempts"
+    AFTER_ATTEMPTS = "after_attempts"
 
 class RANDOMIZATION(object):
     """

--- a/common/lib/xmodule/xmodule/capa_base_constants.py
+++ b/common/lib/xmodule/xmodule/capa_base_constants.py
@@ -16,7 +16,7 @@ class SHOWANSWER(object):
     CORRECT_OR_PAST_DUE = "correct_or_past_due"
     PAST_DUE = "past_due"
     NEVER = "never"
-    AFTER_ATTEMPTS = "after_attempts"
+    AFTER_SOME_NUMBER_OF_ATTEMPTS = "after_attempts"
 
 
 class RANDOMIZATION(object):

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -368,19 +368,18 @@ class CapaModuleTest(unittest.TestCase):
         times.
         '''
         before_attempts_with_max = CapaFactory.create(
-                showanswer="after_attempts",
-                attempts="2",
-                attempts_before_showanswer_button="3",
-                max_attempts="5"
+            showanswer="after_attempts",
+            attempts="2",
+            attempts_before_showanswer_button="3",
+            max_attempts="5"
         )
         self.assertFalse(before_attempts_with_max.answer_available())
 
-
     def test_showanswer_after_attempts_no_max(self):
         before_attempts_no_max = CapaFactory.create(
-                showanswer="after_attempts",
-                attempts="2",
-                attempts_before_showanswer_button="3"
+            showanswer="after_attempts",
+            attempts="2",
+            attempts_before_showanswer_button="3"
         )
         self.assertFalse(before_attempts_no_max.answer_available())
 
@@ -390,20 +389,20 @@ class CapaModuleTest(unittest.TestCase):
         even with the due date in the future
         '''
         used_all_attempts = CapaFactory.create(
-                showanswer='after_attempts',
-                attempts_before_showanswer_button="2",
-                max_attempts="3",
-                attempts="3",
-                due=self.tomorrow_str
+            showanswer='after_attempts',
+            attempts_before_showanswer_button="2",
+            max_attempts="3",
+            attempts="3",
+            due=self.tomorrow_str
         )
         self.assertTrue(used_all_attempts.answer_available())
 
     def test_showanswer_after_attempts_past_due_date(self):
         past_due_date = CapaFactory.create(
-                showanswer='after_attempts',
-                attempts_before_showanswer_button="2",
-                attempts="2",
-                due=self.yesterday_str
+            showanswer='after_attempts',
+            attempts_before_showanswer_button="2",
+            attempts="2",
+            due=self.yesterday_str
         )
         self.assertTrue(past_due_date.answer_available())
 
@@ -413,11 +412,11 @@ class CapaModuleTest(unittest.TestCase):
         User has already attempted for the required number of times
         '''
         still_in_grace = CapaFactory.create(
-                showanswer='after_attempts',
-                after_attempts="3",
-                attempts="4",
-                due=self.yesterday_str,
-                graceperiod=self.two_day_delta_str
+            showanswer='after_attempts',
+            after_attempts="3",
+            attempts="4",
+            due=self.yesterday_str,
+            graceperiod=self.two_day_delta_str
         )
         self.assertTrue(still_in_grace.answer_available())
 
@@ -427,10 +426,10 @@ class CapaModuleTest(unittest.TestCase):
         after all attempts are used up, i.e after_attempts becomes max_attempts
         '''
         large_after_attempts = CapaFactory.create(
-                showanswer='after_attempts',
-                attempts_before_showanswer_button="5",
-                max_attempts="3",
-                attempts="3"
+            showanswer='after_attempts',
+            attempts_before_showanswer_button="5",
+            max_attempts="3",
+            attempts="3"
         )
         self.assertTrue(large_after_attempts.answer_available())
 
@@ -441,9 +440,9 @@ class CapaModuleTest(unittest.TestCase):
         be visible.
         '''
         zero_after_attempts = CapaFactory.create(
-                showanswer='after_attempts',
-                attempts_before_showanswer_button='0',
-                attempts='0'
+            showanswer='after_attempts',
+            attempts_before_showanswer_button='0',
+            attempts='0'
         )
         self.assertTrue(zero_after_attempts.answer_available())
 

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -375,17 +375,15 @@ class CapaModuleTest(unittest.TestCase):
         # answering question for the required number of
         # times.
         before_attempts_with_max = CapaFactory.create(showanswer="after_attempts",
-                                             attempts="2",
-                                             attempts_before_showanswer_button="3",
-                                             max_attempts="5")
+                                                      attempts="2",
+                                                      attempts_before_showanswer_button="3",
+                                                      max_attempts="5")
         self.assertFalse(before_attempts_with_max.answer_available())
-        
         # can't see answer even when max_attempts is not set.
         before_attempts_no_max = CapaFactory.create(showanswer="after_attempts",
-                                             attempts="2",
-                                             attempts_before_showanswer_button="3")
+                                                    attempts="2",
+                                                    attempts_before_showanswer_button="3")
         self.assertFalse(before_attempts_no_max.answer_available())
-        
         # can see answer even after all attempts are used up,
         # even with the due date in the future
         used_all_attempts = CapaFactory.create(showanswer='after_attempts',
@@ -394,14 +392,12 @@ class CapaModuleTest(unittest.TestCase):
                                                attempts="3",
                                                due=self.tomorrow_str)
         self.assertTrue(used_all_attempts.answer_available())
-
         # can see after due date
         past_due_date = CapaFactory.create(showanswer='after_attempts',
                                            attempts_before_showanswer_button="2",
                                            attempts="2",
                                            due=self.yesterday_str)
         self.assertTrue(past_due_date.answer_available())
-
         # Can see even though grace period hasn't expired as long as
         # User has already attempted for the required number of times
         still_in_grace = CapaFactory.create(showanswer='after_attempts',
@@ -410,22 +406,20 @@ class CapaModuleTest(unittest.TestCase):
                                             due=self.yesterday_str,
                                             graceperiod=self.two_day_delta_str)
         self.assertTrue(still_in_grace.answer_available())
-        
         # Ensure that if attempts_before_showanswer_button > max_attempts, the button shows up
         # after all attempts are used up, i.e after_attempts becomes max_attempts
-        large_after_attempts  = CapaFactory.create(showanswer='after_attempts',
-                                                   attempts_before_showanswer_button="5",
-                                                   max_attempts="3",
-                                                   attempts="3")
+        large_after_attempts = CapaFactory.create(showanswer='after_attempts',
+                                                  attempts_before_showanswer_button="5",
+                                                  max_attempts="3",
+                                                  attempts="3")
         self.assertTrue(large_after_attempts.answer_available())
-        
         # If attempts_before_showanswer_button is 0, then the show_answer button should always
         # be visible.
         zero_after_attempts = CapaFactory.create(showanswer='after_attempts',
                                                  attempts_before_showanswer_button='0',
                                                  attempts='0')
         self.assertTrue(zero_after_attempts.answer_available())
-        
+
     def test_showanswer_finished(self):
         """
         With showanswer="finished" should show answer after the problem is closed,

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -362,104 +362,111 @@ class CapaModuleTest(unittest.TestCase):
         self.assertFalse(still_in_grace.answer_available())
 
     def test_showanswer_after_attempts_with_max(self):
-        '''
+        """
         Button should not be visible when attempts < required attempts.
+
         Even with max attempts set, the show answer button should only
         show up after the user has attempted answering the question for
         the requisite number of times, i.e `attempts_before_showanswer_button`
-        '''
+        """
         problem = CapaFactory.create(
-            showanswer="after_attempts",
-            attempts="2",
-            attempts_before_showanswer_button="3",
-            max_attempts="5"
+            showanswer='after_attempts',
+            attempts='2',
+            attempts_before_showanswer_button='3',
+            max_attempts='5',
         )
         self.assertFalse(problem.answer_available())
 
     def test_showanswer_after_attempts_no_max(self):
-        '''
+        """
         Button should not be visible when attempts < required attempts.
+
         Even when max attempts is NOT set, the answer should still
         only be available after the student has attempted the
         problem at least `attempts_before_showanswer_button` times
-        '''
+        """
         problem = CapaFactory.create(
-            showanswer="after_attempts",
-            attempts="2",
-            attempts_before_showanswer_button="3"
+            showanswer='after_attempts',
+            attempts='2',
+            attempts_before_showanswer_button='3',
         )
         self.assertFalse(problem.answer_available())
 
     def test_showanswer_after_attempts_used_all_attempts(self):
-        '''
+        """
         Button should be visible even after all attempts are used up.
+
         As long as the student has attempted  the question for
         the requisite number of times, then the show ans. button is
         visible even after they have exhausted their attempts.
-        '''
+        """
         problem = CapaFactory.create(
             showanswer='after_attempts',
-            attempts_before_showanswer_button="2",
-            max_attempts="3",
-            attempts="3",
-            due=self.tomorrow_str
+            attempts_before_showanswer_button='2',
+            max_attempts='3',
+            attempts='3',
+            due=self.tomorrow_str,
         )
         self.assertTrue(problem.answer_available())
 
     def test_showanswer_after_attempts_past_due_date(self):
-        '''
+        """
         Show Answer button should be visible even after the due date.
+
         As long as the student has attempted the problem for the requisite
         number of times, the answer should be available past the due date.
-        '''
+        """
         problem = CapaFactory.create(
             showanswer='after_attempts',
-            attempts_before_showanswer_button="2",
-            attempts="2",
-            due=self.yesterday_str
+            attempts_before_showanswer_button='2',
+            attempts='2',
+            due=self.yesterday_str,
         )
         self.assertTrue(problem.answer_available())
 
     def test_showanswer_after_attempts_still_in_grace(self):
-        '''
+        """
         If attempts > required attempts, ans. is available in grace period.
+
         As long as the user has attempted for the requisite # of times,
         the show answer button is visible throughout the grace period.
-        '''
+        """
         problem = CapaFactory.create(
             showanswer='after_attempts',
-            after_attempts="3",
-            attempts="4",
+            after_attempts='3',
+            attempts='4',
             due=self.yesterday_str,
-            graceperiod=self.two_day_delta_str
+            graceperiod=self.two_day_delta_str,
         )
         self.assertTrue(problem.answer_available())
 
     def test_showanswer_after_attempts_large(self):
-        '''
+        """
         If required attempts > max attempts then required attempts = max attempts.
+
         Ensure that if attempts_before_showanswer_button > max_attempts,
         the button should show up after all attempts are used up,
         i.e after_attempts falls back to max_attempts
-        '''
+        """
         problem = CapaFactory.create(
             showanswer='after_attempts',
-            attempts_before_showanswer_button="5",
-            max_attempts="3",
-            attempts="3"
+            attempts_before_showanswer_button='5',
+            max_attempts='3',
+            attempts='3',
         )
         self.assertTrue(problem.answer_available())
 
     def test_showanswer_after_attempts_zero(self):
-        '''
+        """
         Button should always be visible if required min attempts = 0.
+
         If attempts_before_showanswer_button = 0, then the show answer
         button should be visible at all times.
-        '''
+        """
         problem = CapaFactory.create(
             showanswer='after_attempts',
             attempts_before_showanswer_button='0',
-            attempts='0'
+            attempts='0',
         )
         self.assertTrue(problem.answer_available())
 

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -351,7 +351,7 @@ class CapaModuleTest(unittest.TestCase):
                                                 attempts="0",
                                                 due=self.tomorrow_str)
         self.assertFalse(attempts_left_open.answer_available())
-
+        
         # Can't see because grace period hasn't expired, even though have no more
         # attempts.
         still_in_grace = CapaFactory.create(showanswer='past_due',
@@ -360,7 +360,50 @@ class CapaModuleTest(unittest.TestCase):
                                             due=self.yesterday_str,
                                             graceperiod=self.two_day_delta_str)
         self.assertFalse(still_in_grace.answer_available())
-
+        
+    def test_showanswer_after_attempts(self):
+        """
+        With showanswer="after_attempts", 
+        the show answer button should 
+        only appear after the user has 
+        attempted the problem(i.e clicked the
+        submit button) for the requisite number of times.
+        
+        Once the button appears, it does not disappear again.
+        """
+        # Cannot see answer because user has not attempted
+        # answering question for the required number of
+        # times.
+        before_attempts = CapaFactory.create(showanswer="after_attempts",
+                                             attempts="2",
+                                             after_attempts="3")
+        self.assertFalse(before_Attempts.answer_available())
+        
+        # can see answer even after all attempts are used up, 
+        # even with the due date in the future
+        used_all_attempts = CapaFactory.create(showanswer='after_attempts',
+                                               after_attempts="2",
+                                               max_attempts="3",
+                                               attempts="3",
+                                               due=self.tomorrow_str)
+        self.assertTrue(used_all_attempts.answer_available())
+        
+        # can see after due date
+        past_due_date = CapaFactory.create(showanswer='after_attempts',
+                                           after_attempts="2",
+                                           attempts="2",
+                                           due=self.yesterday_str)
+        self.assertTrue(past_due_date.answer_available())
+        
+        # Can see even though grace period hasn't expired as long as
+        # User has already attempted for the required number of times
+        still_in_grace = CapaFactory.create(showanswer='after_attempts',
+                                            after_attempts="3",
+                                            attempts="4",
+                                            due=self.yesterday_str,
+                                            graceperiod=self.two_day_delta_str)
+        self.assertTrue(still_in_grace.answer_available())
+                                             
     def test_showanswer_finished(self):
         """
         With showanswer="finished" should show answer after the problem is closed,

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -351,7 +351,7 @@ class CapaModuleTest(unittest.TestCase):
                                                 attempts="0",
                                                 due=self.tomorrow_str)
         self.assertFalse(attempts_left_open.answer_available())
-        
+
         # Can't see because grace period hasn't expired, even though have no more
         # attempts.
         still_in_grace = CapaFactory.create(showanswer='past_due',
@@ -360,15 +360,15 @@ class CapaModuleTest(unittest.TestCase):
                                             due=self.yesterday_str,
                                             graceperiod=self.two_day_delta_str)
         self.assertFalse(still_in_grace.answer_available())
-        
+
     def test_showanswer_after_attempts(self):
         """
-        With showanswer="after_attempts", 
-        the show answer button should 
-        only appear after the user has 
+        With showanswer="after_attempts",
+        the show answer button should
+        only appear after the user has
         attempted the problem(i.e clicked the
         submit button) for the requisite number of times.
-        
+
         Once the button appears, it does not disappear again.
         """
         # Cannot see answer because user has not attempted
@@ -378,8 +378,8 @@ class CapaModuleTest(unittest.TestCase):
                                              attempts="2",
                                              after_attempts="3")
         self.assertFalse(before_Attempts.answer_available())
-        
-        # can see answer even after all attempts are used up, 
+
+        # can see answer even after all attempts are used up,
         # even with the due date in the future
         used_all_attempts = CapaFactory.create(showanswer='after_attempts',
                                                after_attempts="2",
@@ -387,14 +387,14 @@ class CapaModuleTest(unittest.TestCase):
                                                attempts="3",
                                                due=self.tomorrow_str)
         self.assertTrue(used_all_attempts.answer_available())
-        
+
         # can see after due date
         past_due_date = CapaFactory.create(showanswer='after_attempts',
                                            after_attempts="2",
                                            attempts="2",
                                            due=self.yesterday_str)
         self.assertTrue(past_due_date.answer_available())
-        
+
         # Can see even though grace period hasn't expired as long as
         # User has already attempted for the required number of times
         still_in_grace = CapaFactory.create(showanswer='after_attempts',
@@ -403,7 +403,7 @@ class CapaModuleTest(unittest.TestCase):
                                             due=self.yesterday_str,
                                             graceperiod=self.two_day_delta_str)
         self.assertTrue(still_in_grace.answer_available())
-                                             
+
     def test_showanswer_finished(self):
         """
         With showanswer="finished" should show answer after the problem is closed,

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -363,88 +363,105 @@ class CapaModuleTest(unittest.TestCase):
 
     def test_showanswer_after_attempts_with_max(self):
         '''
-        Cannot see answer because user has not attempted
-        answering question for the required number of
-        times.
+        Button should not be visible when attempts < required attempts.
+        Even with max attempts set, the show answer button should only
+        show up after the user has attempted answering the question for
+        the requisite number of times, i.e `attempts_before_showanswer_button`
         '''
-        before_attempts_with_max = CapaFactory.create(
+        problem = CapaFactory.create(
             showanswer="after_attempts",
             attempts="2",
             attempts_before_showanswer_button="3",
             max_attempts="5"
         )
-        self.assertFalse(before_attempts_with_max.answer_available())
+        self.assertFalse(problem.answer_available())
 
     def test_showanswer_after_attempts_no_max(self):
-        before_attempts_no_max = CapaFactory.create(
+        '''
+        Button should not be visible when attempts < required attempts.
+        Even when max attempts is NOT set, the answer should still
+        only be available after the student has attempted the
+        problem at least `attempts_before_showanswer_button` times
+        '''
+        problem = CapaFactory.create(
             showanswer="after_attempts",
             attempts="2",
             attempts_before_showanswer_button="3"
         )
-        self.assertFalse(before_attempts_no_max.answer_available())
+        self.assertFalse(problem.answer_available())
 
     def test_showanswer_after_attempts_used_all_attempts(self):
         '''
-        can see answer even after all attempts are used up,
-        even with the due date in the future
+        Button should be visible even after all attempts are used up.
+        As long as the student has attempted  the question for
+        the requisite number of times, then the show ans. button is
+        visible even after they have exhausted their attempts.
         '''
-        used_all_attempts = CapaFactory.create(
+        problem = CapaFactory.create(
             showanswer='after_attempts',
             attempts_before_showanswer_button="2",
             max_attempts="3",
             attempts="3",
             due=self.tomorrow_str
         )
-        self.assertTrue(used_all_attempts.answer_available())
+        self.assertTrue(problem.answer_available())
 
     def test_showanswer_after_attempts_past_due_date(self):
-        past_due_date = CapaFactory.create(
+        '''
+        Show Answer button should be visible even after the due date.
+        As long as the student has attempted the problem for the requisite
+        number of times, the answer should be available past the due date.
+        '''
+        problem = CapaFactory.create(
             showanswer='after_attempts',
             attempts_before_showanswer_button="2",
             attempts="2",
             due=self.yesterday_str
         )
-        self.assertTrue(past_due_date.answer_available())
+        self.assertTrue(problem.answer_available())
 
     def test_showanswer_after_attempts_still_in_grace(self):
         '''
-        Can see even though grace period hasn't expired as long as
-        User has already attempted for the required number of times
+        If attempts > required attempts, ans. is available in grace period.
+        As long as the user has attempted for the requisite # of times,
+        the show answer button is visible throughout the grace period.
         '''
-        still_in_grace = CapaFactory.create(
+        problem = CapaFactory.create(
             showanswer='after_attempts',
             after_attempts="3",
             attempts="4",
             due=self.yesterday_str,
             graceperiod=self.two_day_delta_str
         )
-        self.assertTrue(still_in_grace.answer_available())
+        self.assertTrue(problem.answer_available())
 
     def test_showanswer_after_attempts_large(self):
         '''
-        Ensure that if attempts_before_showanswer_button > max_attempts, the button shows up
-        after all attempts are used up, i.e after_attempts becomes max_attempts
+        If required attempts > max attempts then required attempts = max attempts.
+        Ensure that if attempts_before_showanswer_button > max_attempts,
+        the button should show up after all attempts are used up,
+        i.e after_attempts falls back to max_attempts
         '''
-        large_after_attempts = CapaFactory.create(
+        problem = CapaFactory.create(
             showanswer='after_attempts',
             attempts_before_showanswer_button="5",
             max_attempts="3",
             attempts="3"
         )
-        self.assertTrue(large_after_attempts.answer_available())
+        self.assertTrue(problem.answer_available())
 
     def test_showanswer_after_attempts_zero(self):
         '''
-        If attempts_before_showanswer_button is 0,
-        then the show_answer button should always
-        be visible.
+        Button should always be visible if required min attempts = 0.
+        If attempts_before_showanswer_button = 0, then the show answer
+        button should be visible at all times.
         '''
-        zero_after_attempts = CapaFactory.create(
+        problem = CapaFactory.create(
             showanswer='after_attempts',
             attempts_before_showanswer_button='0',
             attempts='0'
         )
-        self.assertTrue(zero_after_attempts.answer_available())
+        self.assertTrue(problem.answer_available())
 
     def test_showanswer_finished(self):
         """

--- a/common/lib/xmodule/xmodule/tests/test_capa_module.py
+++ b/common/lib/xmodule/xmodule/tests/test_capa_module.py
@@ -361,63 +361,90 @@ class CapaModuleTest(unittest.TestCase):
                                             graceperiod=self.two_day_delta_str)
         self.assertFalse(still_in_grace.answer_available())
 
-    def test_showanswer_after_attempts(self):
-        """
-        With showanswer="after_attempts",
-        the show answer button should
-        only appear after the user has
-        attempted the problem(i.e clicked the
-        submit button) for the requisite number of times.
-
-        Once the button appears, it does not disappear again.
-        """
-        # Cannot see answer because user has not attempted
-        # answering question for the required number of
-        # times.
-        before_attempts_with_max = CapaFactory.create(showanswer="after_attempts",
-                                                      attempts="2",
-                                                      attempts_before_showanswer_button="3",
-                                                      max_attempts="5")
+    def test_showanswer_after_attempts_with_max(self):
+        '''
+        Cannot see answer because user has not attempted
+        answering question for the required number of
+        times.
+        '''
+        before_attempts_with_max = CapaFactory.create(
+                showanswer="after_attempts",
+                attempts="2",
+                attempts_before_showanswer_button="3",
+                max_attempts="5"
+        )
         self.assertFalse(before_attempts_with_max.answer_available())
-        # can't see answer even when max_attempts is not set.
-        before_attempts_no_max = CapaFactory.create(showanswer="after_attempts",
-                                                    attempts="2",
-                                                    attempts_before_showanswer_button="3")
+
+
+    def test_showanswer_after_attempts_no_max(self):
+        before_attempts_no_max = CapaFactory.create(
+                showanswer="after_attempts",
+                attempts="2",
+                attempts_before_showanswer_button="3"
+        )
         self.assertFalse(before_attempts_no_max.answer_available())
-        # can see answer even after all attempts are used up,
-        # even with the due date in the future
-        used_all_attempts = CapaFactory.create(showanswer='after_attempts',
-                                               attempts_before_showanswer_button="2",
-                                               max_attempts="3",
-                                               attempts="3",
-                                               due=self.tomorrow_str)
+
+    def test_showanswer_after_attempts_used_all_attempts(self):
+        '''
+        can see answer even after all attempts are used up,
+        even with the due date in the future
+        '''
+        used_all_attempts = CapaFactory.create(
+                showanswer='after_attempts',
+                attempts_before_showanswer_button="2",
+                max_attempts="3",
+                attempts="3",
+                due=self.tomorrow_str
+        )
         self.assertTrue(used_all_attempts.answer_available())
-        # can see after due date
-        past_due_date = CapaFactory.create(showanswer='after_attempts',
-                                           attempts_before_showanswer_button="2",
-                                           attempts="2",
-                                           due=self.yesterday_str)
+
+    def test_showanswer_after_attempts_past_due_date(self):
+        past_due_date = CapaFactory.create(
+                showanswer='after_attempts',
+                attempts_before_showanswer_button="2",
+                attempts="2",
+                due=self.yesterday_str
+        )
         self.assertTrue(past_due_date.answer_available())
-        # Can see even though grace period hasn't expired as long as
-        # User has already attempted for the required number of times
-        still_in_grace = CapaFactory.create(showanswer='after_attempts',
-                                            after_attempts="3",
-                                            attempts="4",
-                                            due=self.yesterday_str,
-                                            graceperiod=self.two_day_delta_str)
+
+    def test_showanswer_after_attempts_still_in_grace(self):
+        '''
+        Can see even though grace period hasn't expired as long as
+        User has already attempted for the required number of times
+        '''
+        still_in_grace = CapaFactory.create(
+                showanswer='after_attempts',
+                after_attempts="3",
+                attempts="4",
+                due=self.yesterday_str,
+                graceperiod=self.two_day_delta_str
+        )
         self.assertTrue(still_in_grace.answer_available())
-        # Ensure that if attempts_before_showanswer_button > max_attempts, the button shows up
-        # after all attempts are used up, i.e after_attempts becomes max_attempts
-        large_after_attempts = CapaFactory.create(showanswer='after_attempts',
-                                                  attempts_before_showanswer_button="5",
-                                                  max_attempts="3",
-                                                  attempts="3")
+
+    def test_showanswer_after_attempts_large(self):
+        '''
+        Ensure that if attempts_before_showanswer_button > max_attempts, the button shows up
+        after all attempts are used up, i.e after_attempts becomes max_attempts
+        '''
+        large_after_attempts = CapaFactory.create(
+                showanswer='after_attempts',
+                attempts_before_showanswer_button="5",
+                max_attempts="3",
+                attempts="3"
+        )
         self.assertTrue(large_after_attempts.answer_available())
-        # If attempts_before_showanswer_button is 0, then the show_answer button should always
-        # be visible.
-        zero_after_attempts = CapaFactory.create(showanswer='after_attempts',
-                                                 attempts_before_showanswer_button='0',
-                                                 attempts='0')
+
+    def test_showanswer_after_attempts_zero(self):
+        '''
+        If attempts_before_showanswer_button is 0,
+        then the show_answer button should always
+        be visible.
+        '''
+        zero_after_attempts = CapaFactory.create(
+                showanswer='after_attempts',
+                attempts_before_showanswer_button='0',
+                attempts='0'
+        )
         self.assertTrue(zero_after_attempts.answer_available())
 
     def test_showanswer_finished(self):


### PR DESCRIPTION
@caesar2164 @stvstnfrd @caseylitton  PR for new Studio Feature requested by Jeff Ullman. Allow course creators to specify that the show answer button only shows up after the student makes at least # attempts.
@jspayd @potsui

When testing, ensure that you are logged in as a student to see the effects of the question settings.

