### PR TITLE
Make `register_cme/extrainfo/` in Django Admin user-friendly

### DIFF
--- a/openedx/stanford/djangoapps/register_cme/admin.py
+++ b/openedx/stanford/djangoapps/register_cme/admin.py
@@ -2,13 +2,29 @@
 from __future__ import unicode_literals
 
 from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin
+from django.contrib.auth.models import User
+from django.utils.html import format_html
 
 from .models import ExtraInfo
 
+
 class ExtraInfoAdmin(admin.ModelAdmin):
-    """ Admin interface for ExtraInfo model. """
-    list_display = ('user', 'get_email', 'last_name', 'first_name',)
-    search_fields = ('user__username', 'user__email', 'last_name', 'first_name',)
+    """
+    Admin interface for ExtraInfo model.
+    """
+    list_display = (
+        'user',
+        'get_email',
+        'last_name',
+        'first_name',
+    )
+    search_fields = (
+        'user__username',
+        'user__email',
+        'last_name',
+        'first_name',
+    )
 
     def get_email(self, obj):
         return obj.user.email
@@ -17,4 +33,31 @@ class ExtraInfoAdmin(admin.ModelAdmin):
     class Meta(object):
         model = ExtraInfo
 
+
+class NewUserAdmin(UserAdmin):
+    """
+    Modifies admin interface for User model to display additional ExtraInfo link.
+    """
+    list_display = (
+        'username',
+        'email',
+        'first_name',
+        'last_name',
+        'is_staff',
+        'has_extra_info',
+    )
+
+    def has_extra_info(self, obj):
+        if hasattr(obj, 'extrainfo'):
+            return format_html(
+                '<a href="/admin/register_cme/extrainfo/{extrainfo_id}">ExtraInfo</a>',
+                extrainfo_id=obj.extrainfo.id,
+            )
+        else:
+            return ''
+    has_extra_info.short_description = 'ExtraInfo'
+    has_extra_info.allow_tags = True
+
 admin.site.register(ExtraInfo, ExtraInfoAdmin)
+admin.site.unregister(User)
+admin.site.register(User, NewUserAdmin)

--- a/openedx/stanford/djangoapps/register_cme/admin.py
+++ b/openedx/stanford/djangoapps/register_cme/admin.py
@@ -5,4 +5,16 @@ from django.contrib import admin
 
 from .models import ExtraInfo
 
-admin.site.register(ExtraInfo)
+class ExtraInfoAdmin(admin.ModelAdmin):
+    """ Admin interface for ExtraInfo model. """
+    list_display = ('user', 'get_email', 'last_name', 'first_name',)
+    search_fields = ('user__username', 'user__email', 'last_name', 'first_name',)
+
+    def get_email(self, obj):
+        return obj.user.email
+    get_email.short_description = 'Email address'
+
+    class Meta(object):
+        model = ExtraInfo
+
+admin.site.register(ExtraInfo, ExtraInfoAdmin)


### PR DESCRIPTION
@stvstnfrd @caesar2164 @caseylitton : PR for changes to Django Admin displaying CME registration ExtraInfo.

(1-2) `Register_cme/extrainfo` in Django Admin was previously displaying users
as `ExtraInfo` objects which admins had to click on individually to see
each user's information. (3) Also, admins needed to traverse potentially two paths 
(`auth/user/`, and `register_cme/extrainfo/`) to access complete information for a user. 

(1) Each user in `register_cme/extrainfo` is now displayed with fields: username, email, 
last and first name. Username is clickable to view more information. (2) Added search bar 
enables search for users matching query for username, email, last and first name. (3) Also,
`admin/auth/user` displays a new field `Extra Info` which shows a link labelled `true` if the 
user has an `ExtraInfo` object attached. The admin can thus now traverse simply in `admin/auth/user` and branch off to `ExtraInfo` by individual user if appropriate.

Trello: https://trello.com/c/9MMdMlx0/917-make-the-new-registercme-sections-extra-infos-table-in-cme-admin-user-friendly-currently-each-row-says-extrainfo-object

CC: @jspayd @jlikhuva