### PR TITLE
Add tests for extra fields for `affiliation`

### DIFF
--- a/openedx/stanford/djangoapps/register_cme/tests/test_form.py
+++ b/openedx/stanford/djangoapps/register_cme/tests/test_form.py
@@ -171,3 +171,10 @@ class ExtraInfoFormTest(TestCase):
         form = ExtraInfoForm(data)
         is_valid = form.is_valid()
         self.assertFalse(is_valid)
+
+    def test_postal_code_too_short(self):
+        data = self.data
+        data['postal_code'] = '1'
+        form = ExtraInfoForm(data)
+        is_valid = form.is_valid()
+        self.assertFalse(is_valid)

--- a/openedx/stanford/djangoapps/register_cme/tests/test_form.py
+++ b/openedx/stanford/djangoapps/register_cme/tests/test_form.py
@@ -151,3 +151,23 @@ class ExtraInfoFormTest(TestCase):
         form = ExtraInfoForm(data)
         is_valid = form.is_valid()
         self.assertFalse(is_valid)
+
+    @data(None, '', 'ab', 'longsunet')
+    def test_affiliation_sunet_id(self, sunet_id):
+        data = self.data
+        data['affiliation'] = 'Stanford University'
+        data['stanford_department'] = 'Medicine'
+        data['sunet_id'] = sunet_id
+        form = ExtraInfoForm(data)
+        is_valid = form.is_valid()
+        self.assertFalse(is_valid)
+
+    @data(None, '', 'invalid_department')
+    def test_affiliation_stanford_department(self, stanford_department):
+        data = self.data
+        data['affiliation'] = 'Stanford University'
+        data['stanford_department'] = stanford_department
+        data['sunet_id'] = 'sunet_id'
+        form = ExtraInfoForm(data)
+        is_valid = form.is_valid()
+        self.assertFalse(is_valid)


### PR DESCRIPTION
@caesar2164 @caseylitton @stvstnfrd PR for added tests to CME registration form, `clean_affiliation`

When `affiliation` is selected to be "Stanford University,
`stanford_department` and `sunet_id` is required. Function
`clean_affiliation` in `forms.py` checks this. Previously fixed bug
regarding frozen registration screen on invalid inputs (PR #650) and
discovered missing unit tests. Added tests check that form is invalid
given `sunet_id` that is missing or not 3-8 chars long, or
`stanford_department` that is missing or invalid.

CC: @jspayd @jlikhuva