### PR TITLE
Document Stanford's style guide

### DIFF
--- a/openedx/stanford/style/python/collections-multiline.markdown
+++ b/openedx/stanford/style/python/collections-multiline.markdown
@@ -1,0 +1,61 @@
+# Collections: Multiline
+
+## Expectation
+- Define collections (lists, dictionaries, sets) with one item per line
+- Indent lines by one level
+  - don't align with the opening symbol: `(`/`[`/`{`
+
+## Example
+
+### Good
+```python
+words = [
+    'foo',
+    'bar',
+]
+```
+
+### Bad
+```python
+words = ['foo', 'bar',]
+```
+
+```python
+words = ['foo',
+         'bar',]
+```
+
+## Explanation
+Multiline collections are easier to manage (insert/remove)
+when each item is on its own line.
+
+This also reduces long lines, making the code easier to read.
+
+Consider:
+
+```diff
+     'foo',
+-    'bar',
+ ]
+```
+
+```diff
+     'bar',
++    'baz',
+ ]
+```
+
+versus:
+
+```diff
+- words = ['foo', 'bar',]
++ words = ['foo',]
+```
+
+```diff
+- words = ['foo', 'bar',]
++ words = ['foo', 'bar', 'baz',]
+```
+
+External Resources:
+ 1. http://edx.readthedocs.io/projects/edx-developer-guide/en/latest/style_guides/python_guidelines.html#breaking-long-lines

--- a/openedx/stanford/style/python/collections-trailing-comma.markdown
+++ b/openedx/stanford/style/python/collections-trailing-comma.markdown
@@ -1,0 +1,108 @@
+# Collections: Trailing Comma
+
+## Expectation
+- Add a trailing comma to all multiline collections
+  - where syntactically allowed/identical
+
+## Example
+
+### Good
+```python
+words = [
+    'foo',
+    'bar',
+]
+```
+
+```python
+words = {
+    'foo',
+    'bar',
+}
+```
+
+```python
+words = [
+    'foo': 1,
+    'bar': 2,
+]
+```
+
+### Bad
+```python
+words = [
+    'foo',
+    'bar'
+]
+```
+
+```python
+words = {
+    'foo',
+    'bar'
+}
+```
+
+```python
+words = [
+    'foo': 1,
+    'bar': 2
+]
+```
+
+## Explanation
+Trailing commas allow items to be added/removed from the collection
+while minimizing the size of the changeset.
+This reduces the chance of conflicts during merge [1].
+
+Consider:
+
+```diff
+     'foo',
++    'bar',
+ ]
+```
+
+```diff
+     'foo',
+-    'bar',
+ ]
+```
+
+versus:
+
+```diff
+ words = [
+-    'foo'
++    'foo',
++    'bar'
+ ]
+```
+
+```diff
+ words = [
+-    'foo',
+-    'bar'
++    'foo'
+ ]
+```
+
+Consistently requiring trailing commas also helps to reduce the chance
+of a class of logical errors. Consider:
+
+```python
+words = [
+    'foo'
+    'bar'
+]
+```
+
+This snippet is syntactically vaild, but not the logic we intended.
+In Python, consecutive strings are implicitly concatenated. So instead
+of having a 2-item list with elements `'foo'` and `'bar'`, we have a
+1-item list with the element `'foobar'`. By training our eyes (and
+ideally even linters) to always expect a comma at the end of _every_
+line, we reduce the risk of these bugs being introduced.
+
+External Resources:
+ 1. TODO: link to explanation of changeset reduction (drop the diff)

--- a/openedx/stanford/style/python/comments-code.markdown
+++ b/openedx/stanford/style/python/comments-code.markdown
@@ -1,0 +1,20 @@
+# Comments - Code
+
+## Expectation
+- Don't commit commented code
+  - Simply delete the code, adding any explanatory messaging to the
+    commit message, as needed
+
+## Example
+
+### Bad
+```python
+# TODO: Uncomment this code after blah-blah-blah
+```
+
+## Explanation
+Unused code is misleading and leads to false positives while searching
+the codebase, wasting time.
+The cruft also accumulates, as it's often never actually removed.
+
+If we don't need it, we don't need it.

--- a/openedx/stanford/style/python/docstrings.markdown
+++ b/openedx/stanford/style/python/docstrings.markdown
@@ -1,0 +1,108 @@
+# Docstrings
+
+## Expectation
+- Use double-quotes instead of single quotes.
+- Treat all docstrings as if they were multi-line.
+
+## Example
+
+### Good
+```python
+def foo():
+    """
+    Demonstrate a docstring
+    """
+    pass
+```
+
+### Good
+```python
+def foo():
+    """
+    Demonstrate a docstring
+
+    with multiple lines
+    """
+    pass
+```
+
+### Bad
+```python
+def foo():
+    '''
+    Demonstrate a docstring
+    '''
+    pass
+```
+
+### Bad
+```python
+def foo():
+    """ Demonstrate a docstring """
+    pass
+```
+
+### Bad
+```python
+def foo():
+    """ Demonstrate a docstring
+    with multiple lines
+    """
+    pass
+```
+
+### Bad
+```python
+def foo():
+    """ Demonstrate a docstring
+
+    with multiple lines
+    """
+    pass
+```
+
+## Explanation
+From PEP-257:
+> Multi-line docstrings consist of a summary line just like a one-line
+> docstring, followed by a blank line, followed by a more elaborate
+> description. The summary line may be used by automatic indexing tools;
+> it is important that it fits on one line and is separated from the
+> rest of the docstring by a blank line.
+
+### Double-quotes
+From PEP-257:
+> For consistency, always use """triple double quotes""" around docstrings.
+
+### Multi-line strings
+From PEP-257:
+> Triple quotes are used even though the string fits on one line.
+> This makes it easy to later expand it.
+
+Taking this further, we can make it even easier to expand later
+(and minimize the diff) by always treating docstrings as if they were
+already multiline.
+
+Consider:
+
+```diff
+     Demonstrate a docstring
++
++    with multiple lines
+     """
+```
+
+versus:
+
+```diff
+ def foo():
+-    """ Demonstrate a docstring """
++    """
++    Demonstrate a docstring
++
++    with multiple lines
++    """
+     pass
+```
+
+External Resources:
+ 1. https://www.python.org/dev/peps/pep-0257/

--- a/openedx/stanford/style/python/imports-sorting.markdown
+++ b/openedx/stanford/style/python/imports-sorting.markdown
@@ -1,0 +1,24 @@
+# Imports: Sorting
+
+## Expectation
+- Sort imports alphabetically
+
+## Example
+
+### Good
+```python
+import os
+import sys
+```
+
+### Bad
+```python
+import sys
+import os
+```
+
+## Explanation
+Sorted lists are quicker and easier to read and search.
+
+External Resources:
+ 1. https://www.python.org/dev/peps/pep-0008/#id23


### PR DESCRIPTION
I've talked about and brainstormed this quite a bit, finally starting to put it into writing.
The goal is to provide a prescriptive guide to the coding conventions used by our team, synthesizing PEP8, Pylint, and our own in-house guidelines.

The overall document will be a long-running work-in-progress, but this represents the first steps toward canonization.

We should merge individual sections, as they are ready.