### PR TITLE
Hide passwords in crash reports

### DIFF
--- a/openedx/core/djangoapps/user_api/views.py
+++ b/openedx/core/djangoapps/user_api/views.py
@@ -41,32 +41,6 @@ from .accounts import (
 from .accounts.api import check_account_exists
 from .serializers import UserSerializer, UserPreferenceSerializer
 
-# Begin test code
-import sys
-import traceback
-from django.core import mail
-from django.views.debug import ExceptionReporter
-from django.views.debug import SafeExceptionReporterFilter
-
-# Necessary for testing because SafeExceptionReporterFilter is only active in production mode
-class CustomExceptionReporterFilter(SafeExceptionReporterFilter):
-    def is_active(self, request):
-        return True
-
-def send_manually_exception_email(request, e):
-    exc_info = sys.exc_info()
-    reporter = ExceptionReporter(request, is_email=True, *exc_info)
-    reporter.filter = CustomExceptionReporterFilter()
-    subject = e.message.replace('\n', '\\n').replace('\r', '\\r')[:989]
-    message = "%s\n\n%s" % (
-        '\n'.join(traceback.format_exception(*exc_info)),
-        reporter.filter.get_request_repr(request)
-    )
-    mail.mail_admins(
-        subject, message, fail_silently=True,
-        html_message=reporter.get_traceback_html()
-    )
-# End test code
 
 class LoginSessionView(APIView):
     """HTTP end-points for logging in users. """
@@ -146,14 +120,6 @@ class LoginSessionView(APIView):
     @method_decorator(require_post_params(["email", "password"]))
     @method_decorator(csrf_protect)
     def post(self, request):
-        # Begin test code
-        try:
-            raise Exception
-        except Exception as e:
-            request.META['SERVER_NAME'] = 'blah'
-            request.META['SERVER_PORT'] = 18010
-            send_manually_exception_email(request, e)
-        # End test code
         """Log in a user.
 
         You must send all required form fields with the request.
@@ -315,14 +281,6 @@ class RegistrationView(APIView):
 
     @method_decorator(csrf_exempt)
     def post(self, request):
-        # Begin test code
-        try:
-            raise Exception
-        except Exception as e:
-            request.META['SERVER_NAME'] = 'blah'
-            request.META['SERVER_PORT'] = 18010
-            send_manually_exception_email(request, e)
-        # End test code
         """Create the user's account.
 
         You must send all required form fields with the request.

--- a/openedx/stanford/lms/envs/devstack.py
+++ b/openedx/stanford/lms/envs/devstack.py
@@ -5,6 +5,3 @@ FEATURES.update({
     'ENABLE_COURSEWARE_SEARCH': False,
     'USE_DJANGO_PIPELINE': False,
 })
-# Begin test code
-ADMINS=[('Name', 'test@example.com')]
-# End test code

--- a/openedx/stanford/lms/envs/devstack.py
+++ b/openedx/stanford/lms/envs/devstack.py
@@ -5,3 +5,6 @@ FEATURES.update({
     'ENABLE_COURSEWARE_SEARCH': False,
     'USE_DJANGO_PIPELINE': False,
 })
+# Begin test code
+ADMINS=[('Name', 'test@example.com')]
+# End test code


### PR DESCRIPTION
@stvstnfrd @caesar2164 @potsui @jlikhuva
To test this on your devstack, use the test code in commit d0dd08969a1bc4e240f2cbf09b93033a00618fdb. This manually sends a crash report when you register an account (and prints it to the console). Since a lot of HTML is printed out too, I recommend redirecting stdout to a file so you can search through it.

I don't believe it's necessary to test this with the CME theming/form, but I did (since that's where we had been crashing before). To switch to CME theming:
1. On devstack in lms.env.json (sudo if read-only in vim)
2. Add "openedx.stanford.djangoapps.register_cme" to ADDL_INSTALLED_APPS
3. Create "REGISTRATION_EXTENSION_FORM": "openedx.stanford.djangoapps.register_cme.forms.ExtraInfoForm", above REGISTRATION_EXTRA_FIELDS
4. Make all 'optional' values in REGISTRATION_EXTRA_FIELDS be 'hidden' (note: upon reset these are: gender, goals, level_of_education, mailing_address, and year_of_birth)
5. ENABLE_COMBINED_LOGIN_REGISTRATION needs to be true
6. USE_CUSTOM_THEME needs to be true
7. Change "THEME_NAME" to "cme"
8. Clone cme-theme renamed to cme in /edx/app/edxapp/themes/

I think there still might be other places where sensitive information is exposed in crash reports, but I'm not entirely sure how to check.