### PR TITLE
Password reset link decay bug

### DIFF
--- a/common/djangoapps/student/tests/test_reset_password.py
+++ b/common/djangoapps/student/tests/test_reset_password.py
@@ -262,3 +262,17 @@ class ResetPasswordTests(EventTestMixin, TestCase):
         self.assertEquals(confirm_kwargs['token'], self.token)
         self.user = User.objects.get(pk=self.user.pk)
         self.assertTrue(self.user.is_active)
+
+    @patch('student.views.password_reset_confirm')
+    def test_reset_password_mismatch(self, reset_confirm):
+        """
+        Tests that the platform reports an error if, when
+        trying to reset a password, the user repeats the
+        new password incorrectly.
+        """
+        bad_pwds = {"new_password1": "TestPassword1", "new_password2": "TestPassword2"}
+        bad_reset_req = self.request_factory.post('/password_reset_confirm/{0}-{1}/'.format(self.uidb36, self.token), bad_pwds)
+        bad_resp = password_reset_confirm_wrapper(bad_reset_req, self.uidb36, self.token)
+        self.assertEquals(bad_resp.context_data['validlink'], True)
+        self.assertEquals(bad_resp.context_data['form'], None)
+        self.assertEquals(bad_resp.context_data['title'], "Password reset unsuccessful")

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -2258,6 +2258,8 @@ def password_reset_confirm_wrapper(
 
     if request.method == 'POST':
         password = request.POST['new_password1']
+        password_r = request.POST['new_password2'] # The repeated password.
+        
         if settings.FEATURES.get('ENFORCE_PASSWORD_POLICY', False):
             try:
                 validate_password_length(password)
@@ -2290,6 +2292,10 @@ def password_reset_confirm_wrapper(
                 "You are resetting passwords too frequently. Due to security policies, {num} days must elapse between password resets.",
                 num_days
             ).format(num=num_days)
+            
+        # Ensure that the new password is repeated correctly
+        if password != password_r:
+            err_msg = "The two passwords you entered were not exactly the same. Please try again."
 
     if err_msg:
         # We have an password reset attempt which violates some security policy, use the

--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -2258,8 +2258,8 @@ def password_reset_confirm_wrapper(
 
     if request.method == 'POST':
         password = request.POST['new_password1']
-        password_r = request.POST['new_password2'] # The repeated password.
-        
+        repeated_password = request.POST['new_password2']
+
         if settings.FEATURES.get('ENFORCE_PASSWORD_POLICY', False):
             try:
                 validate_password_length(password)
@@ -2292,11 +2292,10 @@ def password_reset_confirm_wrapper(
                 "You are resetting passwords too frequently. Due to security policies, {num} days must elapse between password resets.",
                 num_days
             ).format(num=num_days)
-            
-        # Ensure that the new password is repeated correctly
-        if password != password_r:
-            err_msg = "The two passwords you entered were not exactly the same. Please try again."
 
+        # Ensure that the new password is repeated correctly
+        if password != repeated_password:
+            err_msg = _("The two passwords you entered were not exactly the same. Please try again.")
     if err_msg:
         # We have an password reset attempt which violates some security policy, use the
         # existing Django template to communicate this back to the user


### PR DESCRIPTION
@caesar2164 @caseylitton @stvstnfrd  PR for password reset link 'decay' bug.

Fixes the issue where no error is issued if, when attempting to reset their password, the user
repeats the new password incorrectly.  The code change ensures that the user receives an error message and that the reset link can still be used after the unsuccessful reset attempt.

See this [Trello Card](https://trello.com/c/XHaarPfj/872-entering-a-different-password-in-the-two-password-reset-fields-invalidates-the-password-reset-link) for further details.

@jspayd @potsui