### PR TITLE
Fix None value crash for orientation update

### DIFF
--- a/openedx/core/djangoapps/profile_images/images.py
+++ b/openedx/core/djangoapps/profile_images/images.py
@@ -205,7 +205,8 @@ def _update_exif_orientation(exif, orientation):
     the exif orientation, return a new exif with the orientation set.
     """
     exif_dict = piexif.load(exif)
-    exif_dict['0th'][piexif.ImageIFD.Orientation] = orientation
+    if orientation:
+        exif_dict['0th'][piexif.ImageIFD.Orientation] = orientation
     return piexif.dump(exif_dict)
 
 

--- a/openedx/core/djangoapps/profile_images/tests/test_images.py
+++ b/openedx/core/djangoapps/profile_images/tests/test_images.py
@@ -23,6 +23,7 @@ from ..images import (
     validate_uploaded_image,
     _get_exif_orientation,
     _get_valid_file_types,
+    _update_exif_orientation
 )
 from .helpers import make_image_file, make_uploaded_file
 
@@ -182,6 +183,20 @@ class TestGenerateProfileImages(TestCase):
         with make_image_file(extension='.jpg') as imfile:
             for _, image in self._create_mocked_profile_images(imfile, requested_images):
                 self.check_exif_orientation(image, None)
+
+    def test_update_exif_orientation_without_orientation(self):
+        """
+        Test the update_exif_orientation without orientation will not throw exception.
+        """
+        requested_images = {10: "ten.jpg"}
+        with make_image_file(extension='.jpg') as imfile:
+            for _, image in self._create_mocked_profile_images(imfile, requested_images):
+                self.check_exif_orientation(image, None)
+                exif = image.info.get('exif', piexif.dump({}))
+                self.assertEqual(
+                    _update_exif_orientation(exif, None),
+                    image.info.get('exif', piexif.dump({}))
+                )
 
     def _create_mocked_profile_images(self, image_file, requested_images):
         """


### PR DESCRIPTION
@stvstnfrd @caesar2164 @caseylitton PR for fixing `TypeError: object of type 'NoneType' has no len()` on crash list

Previously, when a user uploads a profile picture with EXIF data without an `orientation` value (embedded image data that specifies how an image is oriented), an uncaught `TypeError: object of type 'NoneType' has no len()` would crash the server.

This fix ensures `orientation` is only updated when its value exists in the original image EXIF, and adds a test to check an image without `orientation` will not throw an exception.

Trello: https://trello.com/c/nYQmFFEj/598-crash-list-typeerror-object-of-type-nonetype-has-no-len
Cherry-picked from upstream: https://github.com/edx/edx-platform/commit/178e497c65ec2f81db9ca8ccd6a1f83d7cd3fd3b

CC: @jspayd @jlikhuva