### PR TITLE
Fix VideoPlayer tests to match updatePlayTime

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
@@ -417,7 +417,7 @@ function (VideoPlayer) {
                         // That's why we have to do this tick(300).
                         jasmine.Clock.tick(300);
                         expect(state.videoPlayer.currentTime).toBe(30);
-                        expect(state.videoPlayer.updatePlayTime).toHaveBeenCalledWith(30, true);
+                        expect(state.videoPlayer.updatePlayTime).toHaveBeenCalledWith(30, 120);
                     });
                 });
             });
@@ -526,7 +526,7 @@ function (VideoPlayer) {
 
                 it('trigger updatePlayTime event', function () {
                     expect(state.videoPlayer.updatePlayTime)
-                        .toHaveBeenCalledWith(60);
+                        .toHaveBeenCalledWith(60, undefined);
                 });
             });
         });
@@ -602,7 +602,7 @@ function (VideoPlayer) {
 
                 runs(function () {
                     state.videoPlayer.goToStartTime = false;
-                    state.videoPlayer.updatePlayTime(60);
+                    state.videoPlayer.updatePlayTime(60, duration);
 
                     expect($('.vidtime')).toHaveHtml('1:00 / 1:00');
                 });
@@ -633,7 +633,7 @@ function (VideoPlayer) {
 
                 runs(function () {
                     state.videoPlayer.goToStartTime = false;
-                    state.videoPlayer.updatePlayTime(60);
+                    state.videoPlayer.updatePlayTime(60, duration);
 
                     expect(state.videoProgressSlider.updatePlayTime)
                         .toHaveBeenCalledWith({


### PR DESCRIPTION
@stvstnfrd @caesar2164 @caseylitton PR to fix failing VideoPlayer local JS tests

Previously, the function `updatePlayTime` was updated to have parameters
`time` and `endTime`. The specs were not updated to pass in the correct
arguments, which resulted in four failing tests. This fix adds in the
correct second argument `endTime` in function calls to and checks containing
`updatePlayTime`.

Commit introducing parameter change:
fb0c24294c3ad6f9f668837384638e1224f37e26

To run the test in edxapp, issue the command: `js-test-tool run common/lib/xmodule/xmodule/js/js_test.yml --use-firefox`

Trello (see failing test output here): https://trello.com/c/QOadxtlj/933-local-js-tests-are-failing-for-videoplayer-as-far-back-as-commit-181df32

CC: @jspayd @jlikhuva