### PR TITLE
Update xblock free text response to v0.1.7

### DIFF
--- a/requirements/edx/stanford.txt
+++ b/requirements/edx/stanford.txt
@@ -2,7 +2,7 @@ unidecode
 xblock-image-modal==0.4.0 
 -e git+https://github.com/openlearninginitiative/xblock-image-coding.git@cee23e3d59943066159ca13839c82a12d9ccf749#egg=xblock_image_coding
 -e git+https://github.com/Stanford-Online/xblock-qualtrics-survey@release/v0.1.1#egg=xblock-qualtrics-survey
--e git+https://github.com/Stanford-Online/xblock-free-text-response@release/v0.1.6#egg=xblock-free-text-response
+-e git+https://github.com/Stanford-Online/xblock-free-text-response@release/v0.1.7#egg=xblock-free-text-response
 -e git+https://github.com/Stanford-Online/xblock-grademe.git@v0.1.1#egg=grademebutton
 -e git+https://github.com/edx-solutions/xblock-ooyala.git@32d52edaa820dbdbf846d8a84f6bccbf0b9c8218#egg=xblock_ooyala_player-master
 -e git+https://github.com/Stanford-Online/xblock-submit-and-compare.git@428b0d0ec12f80a049d0edb166214adff07eb07b#egg=xblock-submit-and-compare


### PR DESCRIPTION
@stvstnfrd @caesar2164 PR for updating FTR release version.

Changes
---

1. *Move cached data from body to seq_content*
Previously, some future update or rogue script could easily tamper with
our cached data attributes on the body element. We moved these data
attributes to be slightly less widely accessible.