### PR TITLE
Make ExtraInfo into fields in Django Admin

### DIFF
--- a/openedx/stanford/djangoapps/register_cme/admin.py
+++ b/openedx/stanford/djangoapps/register_cme/admin.py
@@ -5,4 +5,17 @@ from django.contrib import admin
 
 from .models import ExtraInfo
 
-admin.site.register(ExtraInfo)
+
+class ExtraInfoAdmin(admin.ModelAdmin):
+    """
+    Admin interface for ExtraInfo model.
+    """
+
+    readonly_fields = (
+        'user',
+    )
+
+    class Meta(object):
+        model = ExtraInfo
+
+admin.site.register(ExtraInfo, ExtraInfoAdmin)

--- a/openedx/stanford/djangoapps/register_cme/admin.py
+++ b/openedx/stanford/djangoapps/register_cme/admin.py
@@ -11,9 +11,25 @@ class ExtraInfoAdmin(admin.ModelAdmin):
     Admin interface for ExtraInfo model.
     """
 
+    list_display = (
+        'user',
+        'get_email',
+        'last_name',
+        'first_name',
+    )
     readonly_fields = (
         'user',
     )
+    search_fields = (
+        'user__username',
+        'user__email',
+        'last_name',
+        'first_name',
+    )
+
+    def get_email(self, obj):
+        return obj.user.email
+    get_email.short_description = 'Email address'
 
     class Meta(object):
         model = ExtraInfo


### PR DESCRIPTION
@stvstnfrd @caesar2164 I've cherry-picked the Django Admin features into two branches. This PR makes `ExtraInfo` object into fields and adds search, omits changes to the `User` table from the old PR. Reasons for this below.

Documented changes
---
`Register_cme/extrainfo` in Django Admin was previously displaying users
as `ExtraInfo` objects which admins had to click on individually to see
each user's information. Each user is now displayed with fields:
username, email, last and first name. Username is clickable to view more
information. Added search bar enables search for users matching query for username,
email, last and first name for ease of access in Django Admin.

Links
---
[Reverted PR](https://github.com/Stanford-Online/edx-platform/pull/657)
[Trello](https://trello.com/c/9MMdMlx0/917-change-extrainfo-and-add-extrainfo-link-make-the-new-registercme-sections-extra-infos-table-in-cme-admin-user-friendly-currently)
[Branch w/ cherry-picked changes to `User` table](https://github.com/Stanford-Online/edx-platform/compare/master...potsui:django-admin-user?expand=1)

Notes
---
Looking at the changes in this PR, I didn't find anything concerning. 

I ran just the `User` table changes in the other branch and found each call to `hasattr(obj, 'extrainfo')` results in a separate duplicated query --- meaning when we load the Users table the number of queries we make grows linearly with the total number of users. 

For 10 users, we make 14 queries:
<img width="1440" alt="screen shot 2017-08-08 at 3 25 23 pm" src="https://user-images.githubusercontent.com/16857876/29098224-1bea9592-7c53-11e7-9f75-fa5b33e28b66.png">
For just 1000 users, we would be making over a 1000 queries then??? I think this might be the issue, so I made a PR for the changes I deemed safe.

