### PR TITLE
Add ExtraInfo link in Django admin `/auth/user`

### DIFF
--- a/openedx/stanford/djangoapps/register_cme/admin.py
+++ b/openedx/stanford/djangoapps/register_cme/admin.py
@@ -2,6 +2,9 @@
 from __future__ import unicode_literals
 
 from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin
+from django.contrib.auth.models import User
+from django.utils.html import format_html
 
 from .models import ExtraInfo
 
@@ -34,4 +37,37 @@ class ExtraInfoAdmin(admin.ModelAdmin):
     class Meta(object):
         model = ExtraInfo
 
+
+class NewUserAdmin(UserAdmin):
+    """
+    Modifies admin interface for User model to display additional ExtraInfo link.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(NewUserAdmin, self).__init__(*args, **kwargs)
+        admin.views.main.EMPTY_CHANGELIST_VALUE = ''
+
+    list_display = (
+        'username',
+        'email',
+        'first_name',
+        'last_name',
+        'is_staff',
+        'extrainfo_link',
+    )
+    list_select_related = (
+        'extrainfo',
+    )
+
+    def extrainfo_link(self, obj):
+        return format_html(
+            '<a href="/admin/register_cme/extrainfo/{extrainfo_id}">ExtraInfo</a>',
+            extrainfo_id=obj.extrainfo.id,
+        )
+    extrainfo_link.short_description = 'ExtraInfo'
+    extrainfo_link.allow_tags = True
+
+
 admin.site.register(ExtraInfo, ExtraInfoAdmin)
+admin.site.unregister(User)
+admin.site.register(User, NewUserAdmin)


### PR DESCRIPTION
@stvstnfrd @caesar2164 

To merge after verifying https://github.com/Stanford-Online/edx-platform/pull/674

Adds ExtraInfo link in `auth/user`; refactored to not make an insane number of queries.

CC @jspayd @jlikhuva