### PR TITLE
Fix positioning of Course Talk widget

### DIFF
--- a/lms/static/sass/multicourse/_course_about.scss
+++ b/lms/static/sass/multicourse/_course_about.scss
@@ -415,8 +415,8 @@
     }
 
     >.coursetalk-read-reviews {
-      margin-top: -200px;
-      margin-bottom: 220px;
+      margin-top: 50px;
+      margin-bottom: 0;
     }
 
     header {


### PR DESCRIPTION
@stvstnfrd 

Here's a screenshot of a course about page without our theme:

![screen shot 2017-10-16 at 2 22 33 pm](https://user-images.githubusercontent.com/3364609/31637046-c6d13c2c-b281-11e7-839e-b6db918e7830.png)


it's pretty clear that this is an edX CSS bug, so fixing I'm fixing it by forking platform SASS...

Here's a screenshot with theme and SASS fork implemented:

![screen shot 2017-10-16 at 3 07 23 pm](https://user-images.githubusercontent.com/3364609/31637596-42e37d96-b284-11e7-9dfe-e7f435ea03f3.png)
