### PR TITLE
Directly send logged out Suclass users to TPA when trying to enroll

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -109,7 +109,11 @@ from openedx.core.lib.courses import course_image_url
           location.href = xhr.responseText;
         }
       } else if (xhr.status == 403) {
-          location.href = "${reverse('register_user')}?course_id=${course.id | u}&enrollment_action=enroll";
+          %if settings.SHIB_ONLY_SITE:
+            location.href = "/login?next=${reverse('finish_auth') + '?course_id=' + unicode(course.id) + '&enrollment_action=enroll&next=' + reverse('dashboard') | u}";
+          %else:
+            location.href = "${reverse('register_user')}?course_id=${course.id | u}&enrollment_action=enroll";
+          %endif
       } else {
         $('#register_error').html(
             (xhr.responseText ? xhr.responseText : "${_("An error occurred. Please try again later.")}")


### PR DESCRIPTION
Default flow of sending to register page is unwanted for Suclass as
we don't want users trying to create non-SUNet accounts on it

@stvstnfrd @caesar2164 