### PR TITLE
Unfork unused SASS

### DIFF
--- a/lms/static/sass/partials/base/_variables.scss
+++ b/lms/static/sass/partials/base/_variables.scss
@@ -259,7 +259,6 @@ $m-blue-l2: rgb(66,181,233);
 $m-blue-l3: rgb(89,190,236);
 $m-blue-l4: tint($m-blue,90%);
 $m-blue-l5: tint($m-blue,95%);
-$m-blue-s1: saturate($m-blue,15%);
 $m-blue-l6: #4bb4fb;
 $m-blue-d1: rgb(23,144,199);
 $m-blue-d2: $blue;


### PR DESCRIPTION
This appears to have been introduced (mistakenly?) during conflict
resolution performed by jbau back in 2013! [1][2]

With this change, this SASS file no longer contains any Stanford
modifications.

There are currently no references to this rule in `edx-platform`.
It is, however, referenced in our themed file by the same name.

This raises the larger issue that this leads me to believe that due to
COMP_THEMING, our old copy of this file on our theme is shadowing the
platform version. This means, not only are we carrying technical debt in
the form of unused styling, but worse, we haven't been receiving styling
updates from edx.

[1] 1cedb45b66f80e2dfa6d9f0ac08bbc18e1189f36
[2] https://github.com/Stanford-Online/edx-platform/commit/1cedb45b66f80e2dfa6d9f0ac08bbc18e1189f36