### PR TITLE
Add problem builder to stanford requirements

### DIFF
--- a/lms/djangoapps/grades/tests/test_scores.py
+++ b/lms/djangoapps/grades/tests/test_scores.py
@@ -27,6 +27,8 @@ class TestScoredBlockTypes(TestCase):
         'freetextresponse',
         'image-coding',
         'inline-dropdown',
+        'problem-builder', 'pb-column', 'pb-mcq', 'pb-mrq', 'pb-rating', 'pb-table',
+        'step-builder', 'sb-review-step', 'sb-plot', 'sb-step',
         'stattutor',
         'submit-and-compare',
         'ubcpi',

--- a/requirements/edx/stanford.txt
+++ b/requirements/edx/stanford.txt
@@ -15,3 +15,4 @@ ubcpi-xblock==0.5.3
 -e git+https://github.com/Stanford-Online/EdxAdaptXBlock.git@35ad130a30a682fe06c44acc0735d72296c4e0ff#egg=edxadapt-xblock
 -e git+https://github.com/oppia/xblock.git@9f6b95b7eb7dbabb96b77198a3202604f96adf65#egg=oppia-xblock
 git+https://github.com/mfogel/django-settings-context-processor.git
+git+https://github.com/open-craft/problem-builder.git@v2.6.5#egg=xblock-problem-builder==2.6.5


### PR DESCRIPTION
- version is pinned to the one in edx-platform/requirements/edx/edx-private.txt

To enable: add `problem-builder` to advanced settings of course.