### PR TITLE
Encodes staff profile names as they can be unicode

### DIFF
--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -606,7 +606,7 @@ class Staffing(SysadminDashboardView):
                 for role in roles:
                     for user in role(course.id).users_with_role():
                         datum = [course.id, role, user.username, user.email,
-                                 user.profile.name]
+                                 user.profile.name.encode('utf-8')]
                         data.append(datum)
             header = [_('course_id'),
                       _('role'), _('username'),


### PR DESCRIPTION
This fixes the `500` error we're getting on the staffing page in sysadmin

FYI: this is also a problem upstream...