### PR TITLE
Fix `skip_registration_form` bug for SSO

### DIFF
--- a/lms/static/js/student_account/views/RegisterView.js
+++ b/lms/static/js/student_account/views/RegisterView.js
@@ -75,6 +75,8 @@
                     if (this.autoSubmit) {
                         $(this.el).hide();
                         $('#register-honor_code').prop('checked', true);
+                        $('#register-terms_of_service').prop('checked', true);
+                        $('#register-privacy_policy').prop('checked', true);
                         this.submitForm();
                     }
 


### PR DESCRIPTION
This feature works by automatically pre-filling the registration form,
clicking the "I agree..." legal checkboxes, and then submitting the form
on the user's behalf. The problem, in our use case, is that edX
explicitly wrote this such that it only ever checks the honor code box,
omitting the boxes for both the Privacy Policy and the Terms of Service.
As such, attempting to auto-register fails, warning the user that they
must check the aformentioned boxes.
This isn't the behavior we want; it should be automatic.

The fix is simple; we now also check the other two boxes.
This allows registration to complete automatically.