### PR TITLE
Fix unicode error in cert whitelist command

### DIFF
--- a/lms/djangoapps/certificates/management/commands/cert_whitelist.py
+++ b/lms/djangoapps/certificates/management/commands/cert_whitelist.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Management command which sets or gets the certificate whitelist for a given
 user/course
@@ -108,8 +109,12 @@ class Command(BaseCommand):
                     update_user_whitelist(username, add=add_to_whitelist)
 
         whitelist = CertificateWhitelist.objects.filter(course_id=course)
-        wl_users = '\n'.join(
-            "{u.user.username} {u.user.email} {u.whitelist}".format(u=u)
-            for u in whitelist
+        print(
+            u"User whitelist for course {0}:".format(course_id)
         )
-        print("User whitelist for course {0}:\n{1}".format(course_id, wl_users))
+        for whitelisted in whitelist:
+            username = whitelisted.user.username
+            username = username.encode('utf-8')
+            email = whitelisted.user.email
+            is_whitelisted = whitelisted.whitelist
+            print(username, email, is_whitelisted)


### PR DESCRIPTION
The string formatting here was not unicode-aware, so it would fail when
printing the whitelist for a course where one of the whitelisted users
had a unicode character in their username.

Django 1.8 does not officially support unicode usernames and will not
allow users to register as such. The bug was introduced when our support
staff manually fullfilled a user request to modify their name;
we should not do this.

Worse, since this code concatenated a giant string, instead of printing
out each line directly, this was more difficult to debug, as you
couldn't see which user was breaking things. The printing has been
updated output each user string individually.