### PR TITLE
Fix cert whitelist output unicode issue

### DIFF
--- a/lms/djangoapps/certificates/management/commands/cert_whitelist.py
+++ b/lms/djangoapps/certificates/management/commands/cert_whitelist.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Management command which sets or gets the certificate whitelist for a given
 user/course
@@ -114,7 +113,6 @@ class Command(BaseCommand):
         )
         for whitelisted in whitelist:
             username = whitelisted.user.username
-            username = username.encode('utf-8')
             email = whitelisted.user.email
             is_whitelisted = whitelisted.whitelist
             print(username, email, is_whitelisted)


### PR DESCRIPTION
The unicode header is only necessary for unicode
characters in the actual source code, so it has
been removed. The username field is a unicode
string already so it does not need to be encoded
again, and was causing an error on print.

@caesar2164 @stvstnfrd 