### PR TITLE
Add missing migration, student course enrollment

### DIFF
--- a/common/djangoapps/student/migrations/0008_default_enrollment_honor.py
+++ b/common/djangoapps/student/migrations/0008_default_enrollment_honor.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('student', '0008_auto_20161117_1209'),
+    ]
+    operations = [
+        migrations.AlterField(
+            model_name='courseenrollment',
+            name='mode',
+            field=models.CharField(default='honor', max_length=100),
+        ),
+        migrations.AlterField(
+            model_name='historicalcourseenrollment',
+            name='mode',
+            field=models.CharField(default='honor', max_length=100),
+        ),
+    ]


### PR DESCRIPTION
While the software default course mode was correctly set to `honor`,
the database default was still incorrectly set to `audit`.
This meant that while most enrollments were registered successfully, any
that followed a code path that neglected to pass in a value for course
mode would instead rely on the database's default, which is incorrect
for our cases.

This was fixed by running `makemigrations`, which we presumably should
have done when we made the original change [1].
This has probably been broken all this time, potentially as far back as
December 2016.

We'll need to correct any erroneous entries with the following SQL:

```sql
UPDATE
    student_courseenrollment
SET
    mode = 'honor'
WHERE
    mode = 'audit'
;
```

- [1] d00bb9792086602470f1a8833013df3cf433a546