### PR TITLE
Add timestamp to Get Student Responses Report

### DIFF
--- a/openedx/stanford/lms/djangoapps/instructor_analytics/basic.py
+++ b/openedx/stanford/lms/djangoapps/instructor_analytics/basic.py
@@ -79,7 +79,7 @@ def student_responses(course):
                 else:
                     raw_answers = {}
                     pretty_answers = None
-                yield problem_component_info + [module.student.username, pretty_answers]
+                yield problem_component_info + [module.student.username, pretty_answers, module.modified.strftime("%Y-%m-%d-%H%M")]
                 if not has_answer:
                     has_answer = True
             if has_answer:

--- a/openedx/stanford/lms/djangoapps/instructor_analytics/tests/test_basic.py
+++ b/openedx/stanford/lms/djangoapps/instructor_analytics/tests/test_basic.py
@@ -118,10 +118,10 @@ class TestStudentResponsesAnalyticsBasic(ModuleStoreTestCase):
         )
         course_with_children = modulestore().get_course(self.course.id, depth=4)
         datarows = list(student_responses(course_with_children))
-        self.assertEqual(datarows[0][-1], u'problem_id=student response1')
-        self.assertEqual(datarows[1][-1], u'student response2')
-        self.assertEqual(datarows[2][-1], None)
-        self.assertEqual(datarows[3][-1], u'problem_id=content library response1')
+        self.assertEqual(datarows[0][-2], u'problem_id=student response1')
+        self.assertEqual(datarows[1][-2], u'student response2')
+        self.assertEqual(datarows[2][-2], None)
+        self.assertEqual(datarows[3][-2], u'problem_id=content library response1')
 
     def test_problem_with_no_answer(self):
         section, sub_section, unit, problem = self.create_course_structure()
@@ -135,4 +135,4 @@ class TestStudentResponsesAnalyticsBasic(ModuleStoreTestCase):
         )
         course_with_children = modulestore().get_course(self.course.id, depth=4)
         datarows = list(student_responses(course_with_children))
-        self.assertEqual(datarows[0][-1], None)
+        self.assertEqual(datarows[0][-2], None)

--- a/openedx/stanford/lms/djangoapps/instructor_task/tasks_helper.py
+++ b/openedx/stanford/lms/djangoapps/instructor_task/tasks_helper.py
@@ -542,6 +542,6 @@ def upload_ora2_data(
 
 def student_response_rows(course):
     """ Wrapper to return all (header and data) rows for student responses reports for a course """
-    header = ["Section", "Subsection", "Unit", "Problem", "Order In Course", "Location", "Student", "Response"]
+    header = ["Section", "Subsection", "Unit", "Problem", "Order In Course", "Location", "Student", "Response", "Timestamp"]
     rows = chain([header], student_responses(course))
     return rows


### PR DESCRIPTION
This is especially useful for courses that are re-used across semesters, e.g. LTI.