### PR TITLE
Remove useless comment fork

### DIFF
--- a/cms/lib/xblock/tagging/tagging.py
+++ b/cms/lib/xblock/tagging/tagging.py
@@ -112,7 +112,7 @@ class StructuredTagsAside(XBlockAside):
 
     def get_event_context(self, event_type, event):  # pylint: disable=unused-argument
         """
-        This method return data that should be associated with the "problem_check" event
+        This method return data that should be associated with the "check_problem" event
         """
         if self.saved_tags and event_type == "problem_check":
             return {'saved_tags': self.saved_tags}


### PR DESCRIPTION
This got wonky w/ a cherry-pick some time back;
since the code in the file is identical, the comments should be too.