### PR TITLE
Revert "Fix error on moving component when qualtrics xblock present."

### DIFF
--- a/cms/djangoapps/contentstore/views/item.py
+++ b/cms/djangoapps/contentstore/views/item.py
@@ -1142,7 +1142,7 @@ def create_xblock_info(xblock, data=None, metadata=None, include_ancestor_info=F
 
     xblock_info = {
         'id': unicode(xblock.location),
-        'display_name': unicode(xblock.display_name_with_default),
+        'display_name': xblock.display_name_with_default,
         'category': xblock.category,
         'has_children': xblock.has_children
     }


### PR DESCRIPTION
This reverts commit 1944a43e487e3be600577a9f0b185cfaa8c06824.

Instead of trying to find everywhere this value surfaces, let's instead fix the underlying string:
- https://github.com/Stanford-Online/xblock-qualtrics-survey/pull/10