### PR TITLE
Fixed drop down buttons on header of bulk settings page

### DIFF
--- a/cms/templates/bulksettings.html
+++ b/cms/templates/bulksettings.html
@@ -128,9 +128,6 @@
   </section>
 </div>
 
-<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.3/jquery.min.js"></script>
-
-
 <script type = "text/javascript">
     var position = window.pageYOffset;
     var originalY = $('#settings-header').offset().top;
@@ -159,6 +156,3 @@
 </script>
 
 </%block>
-
-
-


### PR DESCRIPTION
I don't know why this line importing jquery was included here because jquery is usually automatically loaded. However, when I removed this line, it fixes the bug with the drop down buttons on the bulk settings page.
I think it may have to do with the order of the javascript loading, and was likely introduced after pulling from Gingko.