### PR TITLE
Remove course listing from user tab of sysadmin

### DIFF
--- a/lms/djangoapps/dashboard/sysadmin.py
+++ b/lms/djangoapps/dashboard/sysadmin.py
@@ -300,15 +300,6 @@ class Users(SysadminDashboardView):
         self.datatable['data'] = [[_('Total number of users'),
                                    User.objects.all().count()]]
 
-        self.msg += u'<h2>{0}</h2>'.format(
-            _('Courses loaded in the modulestore')
-        )
-        self.msg += u'<ol>'
-        for course in self.get_courses():
-            self.msg += u'<li>{0} ({1})</li>'.format(
-                escape(course.id.to_deprecated_string()), course.location.to_deprecated_string())
-        self.msg += u'</ol>'
-
     def get(self, request):
 
         if not request.user.is_staff:


### PR DESCRIPTION
I'm admittedly unclear why we decided to include a listing of _courses_
in the _users_ tab, when this listing is already available via the
_courses_ tab, which is where you'd expect to find it.

Particularly problematic here is the impact this has on page loads..
For instances with a large number of courses [1], pulling and rendering
adds a nontrivial amount of overhead and leads to longer load times.

In our case, this often leads to a page timeout. Since this is the main
landing page for the sysadmin dashboard, it presents the appearance that
the entire dashboard has crashed. In not being able to access the main
page, you can't access any of the other tabs via navigation, unless you
manually enter the URL :\

[1] ~750 courses, in one example