### PR TITLE
Fix video speed adjustments issue

### DIFF
--- a/common/lib/xmodule/xmodule/js/spec/video/general_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/general_spec.js
@@ -85,7 +85,7 @@
                     });
 
                     it('set current video speed via cookie', function() {
-                        expect(state.speed).toEqual('1.50');
+                        expect(state.speed).toEqual(1.5);
                     });
                 });
 

--- a/common/lib/xmodule/xmodule/js/spec/video/initialize_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/initialize_spec.js
@@ -188,7 +188,7 @@ function(Initialize) {
 
                     $.each(map, function(key, expected) {
                         Initialize.prototype.setSpeed.call(state, key);
-                        expect(state.speed).toBe(expected);
+                        expect(state.speed).toBe(parseFloat(expected));
                     });
                 });
             });
@@ -207,7 +207,7 @@ function(Initialize) {
                     });
 
                     it('set new speed', function() {
-                        expect(state.speed).toEqual('0.75');
+                        expect(state.speed).toEqual(0.75);
                     });
                 });
 
@@ -217,7 +217,7 @@ function(Initialize) {
                     });
 
                     it('set speed to 1.0x', function() {
-                        expect(state.speed).toEqual('1.0');
+                        expect(state.speed).toEqual(1);
                     });
                 });
 
@@ -230,7 +230,7 @@ function(Initialize) {
 
                     $.each(map, function(key, expected) {
                         Initialize.prototype.setSpeed.call(state, key);
-                        expect(state.speed).toBe(expected);
+                        expect(state.speed).toBe(parseFloat(expected));
                     });
                 });
             });

--- a/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
+++ b/common/lib/xmodule/xmodule/js/spec/video/video_player_spec.js
@@ -54,7 +54,7 @@ function(VideoPlayer, HLS) {
 
                 it('create video caption', function() {
                     expect(state.videoCaption).toBeDefined();
-                    expect(state.speed).toEqual('1.50');
+                    expect(state.speed).toEqual(1.5);
                     expect(state.config.transcriptTranslationUrl)
                         .toEqual('/transcript/translation/__lang__');
                 });
@@ -62,7 +62,7 @@ function(VideoPlayer, HLS) {
                 it('create video speed control', function() {
                     expect(state.videoSpeedControl).toBeDefined();
                     expect(state.videoSpeedControl.el).toHaveClass('speeds');
-                    expect(state.speed).toEqual('1.50');
+                    expect(state.speed).toEqual(1.5);
                 });
 
                 it('create video progress slider', function() {

--- a/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
+++ b/common/lib/xmodule/xmodule/js/src/video/01_initialize.js
@@ -701,6 +701,7 @@ function(VideoPlayer, i18n, moment, _) {
             newSpeed = map[newSpeed];
             this.speed = _.contains(this.speeds, newSpeed) ? newSpeed : '1.0';
         }
+        this.speed = parseFloat(this.speed);
     }
 
     function getVideoMetadata(url, callback) {

--- a/common/lib/xmodule/xmodule/js/src/video/08_video_speed_control.js
+++ b/common/lib/xmodule/xmodule/js/src/video/08_video_speed_control.js
@@ -231,21 +231,22 @@
          * not differs from current speed.
          */
         setSpeed: function(speed, silent, forceUpdate) {
-            if (speed !== this.currentSpeed || forceUpdate) {
+            var newSpeed = this.state.speedToString(speed);
+            if (newSpeed !== this.currentSpeed || forceUpdate) {
                 this.speedsContainer
                     .find('li')
-                    .siblings("li[data-speed='" + speed + "']");
+                    .siblings("li[data-speed='" + newSpeed + "']");
 
-                this.speedButton.find('.value').text(speed + 'x');
-                this.currentSpeed = speed;
+                this.speedButton.find('.value').text(newSpeed + 'x');
+                this.currentSpeed = newSpeed;
 
                 if (!silent) {
-                    this.el.trigger('speedchange', [speed, this.state.speed]);
+                    this.el.trigger('speedchange', [newSpeed, this.state.speed]);
                 }
             }
 
             this.resetActiveSpeed();
-            this.setActiveSpeed(speed);
+            this.setActiveSpeed(newSpeed);
         },
 
         resetActiveSpeed: function() {
@@ -259,13 +260,13 @@
         },
 
         setActiveSpeed: function(speed) {
-            var speedOption = this.speedsContainer.find('li[data-speed="' + speed + '"]');
+            var speedOption = this.speedsContainer.find('li[data-speed="' + this.state.speedToString(speed) + '"]');
 
             speedOption.addClass('is-active')
                 .find('.speed-option')
                 .attr('aria-pressed', 'true');
 
-            this.speedButton.attr('title', gettext('Video speed: ') + speed + 'x');
+            this.speedButton.attr('title', gettext('Video speed: ') + this.state.speedToString(speed) + 'x');
         },
 
         /**

--- a/common/lib/xmodule/xmodule/js/src/video/095_video_context_menu.js
+++ b/common/lib/xmodule/xmodule/js/src/video/095_video_context_menu.js
@@ -216,7 +216,8 @@ function(Component) {
         },
 
         appendContent: function(content) {
-            this.getElement().append(content);
+            var $content = $(content);
+            this.getElement().append($content);
             return this;
         },
 
@@ -246,8 +247,8 @@ function(Component) {
         },
 
         open: function() {
-            var menu = (this.isRendered) ? this.getElement() : this.populateElement();
-            this.container.append(menu);
+            var $menu = (this.isRendered) ? this.getElement() : this.populateElement();
+            this.container.append($menu);
             AbstractItem.prototype.open.call(this);
             this.overlay.show(this.container);
             return this;
@@ -354,7 +355,8 @@ function(Component) {
         },
 
         show: function(container) {
-            $(container).append(this.getElement());
+            var $elem = $(this.getElement());
+            $(container).append($elem);
             this.delegateEvents();
             return this;
         },
@@ -389,8 +391,10 @@ function(Component) {
         },
 
         createElement: function() {
-            var element = $('<li />', {
-                'class': ['submenu-item', 'menu-item', this.options.prefix + 'submenu-item'].join(' '),
+            var $spanElem,
+                $listElem,
+                $element = $('<li />', {
+                class: ['submenu-item', 'menu-item', this.options.prefix + 'submenu-item'].join(' '),
                 'aria-expanded': 'false',
                 'aria-haspopup': 'true',
                 'aria-labelledby': 'submenu-item-label-' + this.id,
@@ -398,21 +402,25 @@ function(Component) {
                 'tabindex': -1
             });
 
-            this.label = $('<span />', {
-                'id': 'submenu-item-label-' + this.id,
-                'text': this.options.label
-            }).appendTo(element);
+            $spanElem = $('<span />', {
+                id: 'submenu-item-label-' + this.id,
+                text: this.options.label
+            });
+            this.label = $spanElem.appendTo($element);
 
-            this.list = $('<ol />', {
-                'class': ['submenu', this.options.prefix + 'submenu'].join(' '),
-                'role': 'menu'
-            }).appendTo(element);
+            $listElem = $('<ol />', {
+                class: ['submenu', this.options.prefix + 'submenu'].join(' '),
+                role: 'menu'
+            });
+
+            this.list = $listElem.appendTo($element);
 
             return element;
         },
 
         appendContent: function(content) {
-            this.list.append(content);
+            var $content = $(content);
+            this.list.append($content);
             return this;
         },
 
@@ -627,7 +635,7 @@ function(Component) {
                 }, {
                     label: i18n.Speed,
                     items: _.map(state.speeds, function(speed) {
-                        var isSelected = speed === state.speed;
+                        var isSelected = parseFloat(speed) === state.speed;
                         return {label: speed + 'x', callback: speedCallback, speed: speed, isSelected: isSelected};
                     }),
                     initialize: function(menuitem) {

--- a/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
+++ b/common/lib/xmodule/xmodule/js/src/video/09_events_plugin.js
@@ -100,8 +100,8 @@
             onSpeedChange: function(event, newSpeed, oldSpeed) {
                 this.log('speed_change_video', {
                     current_time: this.getCurrentTime(),
-                    old_speed: oldSpeed,
-                    new_speed: newSpeed
+                    old_speed: this.state.speedToString(oldSpeed),
+                    new_speed: this.state.speedToString(newSpeed)
                 });
             },
 


### PR DESCRIPTION
Fixed bug where refreshing page after adjusting video speed would result in video playing at 1.0x (regardless of speed selected) even though UI would show selected speed.

Issue fixed by cherry-picking upstream bugfix here: https://github.com/edx/edx-platform/pull/19888/commits/a5fe66863eef403ffa4606a22c81ec2a367f1986