### PR TITLE
Fix broken CMS tests imports for bulk utilities

### DIFF
--- a/common/lib/xmodule/xmodule/js/src/video/095_video_context_menu.js
+++ b/common/lib/xmodule/xmodule/js/src/video/095_video_context_menu.js
@@ -394,13 +394,13 @@ function(Component) {
             var $spanElem,
                 $listElem,
                 $element = $('<li />', {
-                class: ['submenu-item', 'menu-item', this.options.prefix + 'submenu-item'].join(' '),
-                'aria-expanded': 'false',
-                'aria-haspopup': 'true',
-                'aria-labelledby': 'submenu-item-label-' + this.id,
-                'role': 'menuitem',
-                'tabindex': -1
-            });
+                    class: ['submenu-item', 'menu-item', this.options.prefix + 'submenu-item'].join(' '),
+                    'aria-expanded': 'false',
+                    'aria-haspopup': 'true',
+                    'aria-labelledby': 'submenu-item-label-' + this.id,
+                    role: 'menuitem',
+                    tabindex: -1
+                });
 
             $spanElem = $('<span />', {
                 id: 'submenu-item-label-' + this.id,

--- a/openedx/stanford/cms/djangoapps/contentstore/tests/test_bulksettings.py
+++ b/openedx/stanford/cms/djangoapps/contentstore/tests/test_bulksettings.py
@@ -1,14 +1,13 @@
 """
 Tests for the bulk settings page
 """
-import unittest
-from contentstore.tests.utils import CourseTestCase
-from contentstore.views.utilities.bulksettings import BulkSettingsUtil
-
-from xmodule.modulestore.tests.factories import ItemFactory, CourseFactory
-
 from datetime import datetime
 import random
+import unittest
+
+from cms.djangoapps.contentstore.tests.utils import CourseTestCase
+from openedx.stanford.cms.djangoapps.contentstore.views.utilities.bulksettings import BulkSettingsUtil
+from xmodule.modulestore.tests.factories import ItemFactory, CourseFactory
 
 
 class BulkSettingsTests(CourseTestCase):

--- a/openedx/stanford/cms/djangoapps/contentstore/tests/test_captions.py
+++ b/openedx/stanford/cms/djangoapps/contentstore/tests/test_captions.py
@@ -10,11 +10,11 @@ from mock import patch
 from django.test.utils import override_settings
 from django.conf import settings
 
+from cms.djangoapps.contentstore.tests.utils import CourseTestCase
 from xmodule.video_module import transcripts_utils
-from contentstore.tests.utils import CourseTestCase
-from contentstore.views.utilities.captions import get_videos
 from openedx.core.djangoapps.contentserver.caching import del_cached_content
 from openedx.stanford.cms.djangoapps.contentstore.views.helpers import reverse_course_url
+from openedx.stanford.cms.djangoapps.contentstore.views.utilities.captions import get_videos
 from xmodule.modulestore.django import modulestore
 from xmodule.contentstore.django import contentstore, _CONTENTSTORE
 from xmodule.contentstore.content import StaticContent
@@ -136,7 +136,7 @@ class TestCheckcaptions(Basetranscripts):
             # Mocks downloading from youtube by saving straight into modulestore
             self.save_subs_to_store(subs, youtube_id)
 
-        with patch('contentstore.views.utilities.captions.download_youtube_subs') as youtube_download:
+        with patch('openedx.stanford.cms.djangoapps.contentstore.views.utilities.captions.download_youtube_subs') as youtube_download:
             youtube_download.side_effect = mock_youtube_download
             link = self.captions_url
             data = {

--- a/openedx/stanford/cms/djangoapps/contentstore/tests/test_utilities.py
+++ b/openedx/stanford/cms/djangoapps/contentstore/tests/test_utilities.py
@@ -1,7 +1,7 @@
 """ Unit tests for utility methods in views.py. """
 from django.conf import settings
+from openedx.stanford.cms.djangoapps.contentstore.views.utility import expand_utility_action_url
 from xmodule.modulestore.django import modulestore
-from contentstore.views.utility import expand_utility_action_url
 from xmodule.modulestore.tests.factories import CourseFactory
 
 import json

--- a/scripts/circle-ci-tests.sh
+++ b/scripts/circle-ci-tests.sh
@@ -108,7 +108,9 @@ else
             echo "Running code complexity report (python)."
             paver run_complexity > reports/code_complexity.log || echo "Unable to calculate code complexity. Ignoring error."
 
-            test_system lms openedx.stanford || EXIT=1
+            test_system lms openedx.stanford.common || EXIT=1
+            test_system lms openedx.stanford.djangoapps || EXIT=1
+            test_system lms openedx.stanford.lms || EXIT=1
             test_system_children lms openedx.features || EXIT=1
             test_system lms openedx.tests || EXIT=1
             test_system lms lms.tests || EXIT=1


### PR DESCRIPTION
This was an oversight on my behalf when previously relocating the bulk utility code.