### PR TITLE
Override ALLOW_COURSE_RERUNS via JSON

### DIFF
--- a/openedx/stanford/cms/envs/common.py
+++ b/openedx/stanford/cms/envs/common.py
@@ -40,7 +40,6 @@ COURSE_UTILITIES = [
     }
 ]
 FEATURES.update({
-    'ALLOW_COURSE_RERUNS': False,
     'ALLOW_HIDING_DISCUSSION_TAB': True,
     # Display option to send email confirmation of course enrollment
     'ENABLE_ENROLLMENT_EMAIL': False,

--- a/openedx/stanford/cms/envs/test.py
+++ b/openedx/stanford/cms/envs/test.py
@@ -1,7 +1,6 @@
 from cms.envs.test import *
 
 
-FEATURES['ALLOW_COURSE_RERUNS'] = True
 INSTALLED_APPS += (
     'openedx.stanford.djangoapps.register_cme',
 )


### PR DESCRIPTION
instead of unilaterally for all Stanford deployments.

Requires: https://github.com/Stanford-Online/configuration/pull/321