### PR TITLE
Remove the word "Student" from the title.

### DIFF
--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -53,7 +53,7 @@ from django.utils.http import urlquote_plus
                 </div>
                 % endif
                 <h2 class="hd hd-2 progress-certificates-title">
-                    ${_("Course Progress for Student '{username}' ({email})").format(username=student.username, email=student.email)}
+                    ${_("Course Progress for '{username}' ({email})").format(username=student.username, email=student.email)}
                 </h2>
 
                 <%include file="progress-info.html" />


### PR DESCRIPTION
At Stanford, we are required to refer to users as participants. Removed the word
Student from the progress certificate title. The word "Student" does not change when the
user context is changed.