### PR TITLE
Hide bulk update settings feature until fixed

### DIFF
--- a/openedx/stanford/cms/envs/common.py
+++ b/openedx/stanford/cms/envs/common.py
@@ -36,16 +36,6 @@ COURSE_UTILITIES = [
                 'action_text': 'View Problem Settings',
                 'action_external': False,
             },
-            {
-                'short_description': 'Bulk update problem settings',
-                'long_description': (
-                    'This utility will allow you to bulk update settings for all existing problems '
-                    'and set them as the default for future problems in Advanced Settings.'
-                ),
-                'action_url': 'utility_bulkupdate_handler',
-                'action_text': 'Update Problem Settings',
-                'action_external': False,
-            },
         ],
     }
 ]


### PR DESCRIPTION
This just removes it from the utilities listing.

It will be easier to troubleshoot if we just need to tweak settings instead of remerge the whole PR.

Without any public link, I'm not worried about super-soft-launching the underlying code.