### PR TITLE
Define CELERY_IMPORTS in stanford settings

### DIFF
--- a/openedx/stanford/cms/envs/common.py
+++ b/openedx/stanford/cms/envs/common.py
@@ -10,6 +10,9 @@ from openedx.stanford.lms.envs.common import (
 
 STANFORD_ROOT = REPO_ROOT / 'openedx/stanford'
 
+CELERY_IMPORTS = (
+    'openedx.stanford.cms.djangoapps.contentstore.views.utilities.tasks',
+)
 COPYRIGHT_EMAIL = 'copyright@example.com'
 COURSE_UTILITIES = [
     # Todo: add aws entries for this


### PR DESCRIPTION
since we have some in a non-standard location;
eg: bulk update settings