### PR TITLE
Add missing migrations

### DIFF
--- a/lms/djangoapps/branding_stanford/migrations/0001_initial.py
+++ b/lms/djangoapps/branding_stanford/migrations/0001_initial.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from django.db import migrations, models
 import django.db.models.deletion
 from django.conf import settings
-from openedx.core.djangoapps import xmodule_django
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class Migration(migrations.Migration):
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
                 ('change_date', models.DateTimeField(auto_now_add=True, verbose_name='Change date')),
                 ('enabled', models.BooleanField(default=False, verbose_name='Enabled')),
                 ('site', models.CharField(default=b'default', max_length=32)),
-                ('course_id', xmodule_django.models.CourseKeyField(max_length=255, db_index=True)),
+                ('course_id', CourseKeyField(max_length=255, db_index=True)),
                 ('changed_by', models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, editable=False, to=settings.AUTH_USER_MODEL, null=True, verbose_name='Changed by')),
             ],
             options={

--- a/lms/djangoapps/branding_stanford/models.py
+++ b/lms/djangoapps/branding_stanford/models.py
@@ -7,7 +7,7 @@ stored in this model.
 from django.db import models
 
 from config_models.models import ConfigurationModel
-from opaque_keys.edx.django.models import UsageKeyField
+from opaque_keys.edx.django.models import CourseKeyField
 
 
 class TileConfiguration(ConfigurationModel):
@@ -15,7 +15,7 @@ class TileConfiguration(ConfigurationModel):
         Stores a list of tiles presented on the front page.
     """
     site = models.CharField(max_length=32, default='default', blank=False)
-    course_id = UsageKeyField(max_length=255, db_index=True)
+    course_id = CourseKeyField(max_length=255, db_index=True)
 
     class Meta(ConfigurationModel.Meta):
         app_label = 'branding_stanford'


### PR DESCRIPTION
The change for `branding_stanford` seems to just be that the data class changed:
- from `CourseKeyField` or some such embedded in `xmodule` to `UsageKeyField` in the external package `opaque_keys`

I'm not sure what's going on with the other one...
Documentation [1] mentions that it should _not_ affect the database itself (code-only), but I'm not sure why it's showing up on our fork and not upstream (I checked `edx/master`).

Curious on thoughts, especially point 2 ^

Maybe we just merge the `branding_stanford` change first and see if sandbox still complains?

- [1] https://docs.djangoproject.com/en/2.2/ref/migration-operations/#altermodeloptions