### PR TITLE
Fix course mode settings import

### DIFF
--- a/openedx/stanford/cms/envs/aws.py
+++ b/openedx/stanford/cms/envs/aws.py
@@ -1,5 +1,5 @@
 from cms.envs.aws import *
-from lms.envs.common import COURSE_MODE_DEFAULTS
+from lms.envs.aws import COURSE_MODE_DEFAULTS
 
 
 CMS_BASE = ENV_TOKENS.get(


### PR DESCRIPTION
Without this, we were pulling edx's default (audit) from common,
instead of pulling "ours" from aws/json (honor).