### PR TITLE
Skip sleep when faking Marketo optin

### DIFF
--- a/openedx/stanford/djangoapps/auth_lagunita/management/commands/opt_in_to_marketing.py
+++ b/openedx/stanford/djangoapps/auth_lagunita/management/commands/opt_in_to_marketing.py
@@ -135,7 +135,7 @@ class Command(BaseCommand):
                     subscribed += 1
                 else:
                     failed += 1
-            time.sleep(0.5)
+                time.sleep(0.5)
         log.info('User lookup completed')
         self.stdout.write('Subscription Summary:')
         self.stdout.write("    Faked: {0}".format(faked))


### PR DESCRIPTION
The `sleep` call exists as a form of naive rate-limiting.
As such, we really only need it when we're actually hitting the API
(`--no-dry-run`), not when we're faking the API hit. Otherwise,
dry-runs can take prohibitively long to run.