### PR TITLE
Update the version of matplotlib running in sandboxes. (#20937)

### DIFF
--- a/requirements/edx-sandbox/base.in
+++ b/requirements/edx-sandbox/base.in
@@ -8,4 +8,4 @@
 #   * run "make upgrade" to update the detailed requirements files
 
 -r shared.txt                       # Dependencies in common with LMS and Studio
-matplotlib==1.3.1                   # 2D plotting library
+matplotlib==1.5.3                   # 2D plotting library

--- a/requirements/edx-sandbox/base.txt
+++ b/requirements/edx-sandbox/base.txt
@@ -12,19 +12,20 @@ asn1crypto==0.24.0
 backports-abc==0.5        # via tornado
 cffi==1.11.5
 cryptography==2.5
+cycler==0.10.0            # via matplotlib
 enum34==1.1.6
 futures==3.2.0            # via tornado
 ipaddress==1.0.22
 lxml==3.8.0
 markupsafe==1.1.0
-matplotlib==1.3.1
+matplotlib==1.5.3
 networkx==1.7
 nltk==3.4
-nose==1.3.7               # via matplotlib
 numpy==1.6.2
 pycparser==2.19
 pyparsing==2.2.0
 python-dateutil==2.8.0    # via matplotlib
+pytz==2019.1              # via matplotlib
 scipy==0.14.0
 singledispatch==3.4.0.3
 six==1.12.0


### PR DESCRIPTION
Changelog can be found here: https://matplotlib.org/1.5.3/users/whats_new.html

This version fixes the odd setup.py in matplotlib that tries to install
numpy as a part of matplotlib setup.py execution.

Looking at the changelog I don't see any incompatibility issues just bug
fixes and feature additions.