### PR TITLE
Revert "Use stanford search logic only if configured"

### DIFF
--- a/openedx/stanford/lms/lib/courseware_search/lms_filter_generator.py
+++ b/openedx/stanford/lms/lib/courseware_search/lms_filter_generator.py
@@ -23,7 +23,5 @@ class TileSearchFilterGenerator(LmsSearchFilterGenerator):
             course_tiles_ids = TileConfiguration.objects.filter(
                 enabled=True,
             ).values_list('course_id', flat=True).order_by('-change_date')
-            courses = list(course_tiles_ids)
-            if len(courses):
-                field_dictionary['course'] = courses
+            field_dictionary['course'] = list(course_tiles_ids)
         return field_dictionary


### PR DESCRIPTION
This reverts commit 61cebe12c001bb42350d8e9e99a7fa7d26fc7667.

I accidentally pushed this to master.

FWIW: I think this should work stand-alone, so if it actually works, we could always keep it, instead of reverting and restoring...